### PR TITLE
Enforce Prettier

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,6 +5,7 @@
 **CompX** is a visual block-based computational graph system with both web and Electron desktop applications. It implements a sophisticated graph computation engine for modeling, simulation, and visual programming.
 
 ### Core Capabilities
+
 - **Block-Based Visual Programming**: Drag-and-drop graph construction with typed ports
 - **Graph Execution Engine**: DFS-based compilation, SCC detection, topological sorting
 - **Multi-Platform**: Web app (React) and Electron desktop application
@@ -13,6 +14,7 @@
 ## Architecture
 
 ### Monorepo Structure (Lerna + npm workspaces)
+
 ```
 CompX/
 ├── packages/
@@ -23,6 +25,7 @@ CompX/
 ```
 
 ### Package Dependencies
+
 - **@compx/common**: Core graph computation library (no UI dependencies)
 - **@compx/web_app**: React/Redux UI → depends on common
 - **@compx/electron_app**: Electron main → bundles web_app + loader
@@ -31,6 +34,7 @@ CompX/
 ## Core Domain Concepts
 
 ### Graph Theory Foundation
+
 CompX implements **directed graph computation** with these key concepts:
 
 1. **Graph**: Container for blocks and edges
@@ -39,6 +43,7 @@ CompX implements **directed graph computation** with these key concepts:
 4. **Port**: Typed data endpoint (number, vector, matrix, boolean, string)
 
 ### Graph Algorithms Implemented
+
 - **DFS (Depth-First Search)**: Graph traversal
 - **SCC (Strongly Connected Components)**: Feedback loop detection via Kosaraju's algorithm
 - **Edge Classification**: Tree, back, forward, cross edges
@@ -46,7 +51,9 @@ CompX implements **directed graph computation** with these key concepts:
 - **Graph Transpose**: For SCC computation
 
 ### Block Execution Model
+
 Blocks use **callback functions** with domain-specific syntax:
+
 - `inputPort[portName]`: Access current input
 - `prevInput[portName]`: Access previous input (creates pseudo-source)
 - `prevOutput[portName]`: Access previous output (for state)
@@ -55,12 +62,14 @@ Blocks use **callback functions** with domain-specific syntax:
 ## Technology Stack
 
 ### Core Libraries
+
 - **TypeScript 4.4.4**: Strict typing throughout
 - **Lodash**: Utility functions for deep cloning, data manipulation
 - **uuid**: Unique identifier generation
 - **loglevel**: Logging infrastructure
 
 ### Frontend (web_app)
+
 - **React 18.2**: UI framework
 - **Redux Toolkit**: State management
 - **React-Konva**: Canvas-based graph visualization
@@ -68,10 +77,12 @@ Blocks use **callback functions** with domain-specific syntax:
 - **Webpack 5**: Build system with dev server
 
 ### Desktop (electron_app)
+
 - **Electron**: Cross-platform desktop wrapper
 - **Window Management**: Custom window manager for app lifecycle
 
 ### Build & Quality
+
 - **Lerna 6.4.1**: Monorepo management
 - **Jest 29**: Testing framework
 - **ESLint + Prettier**: Code quality and formatting
@@ -81,6 +92,7 @@ Blocks use **callback functions** with domain-specific syntax:
 ## Development Patterns
 
 ### Naming Conventions
+
 - **Files**: PascalCase for components, camelCase for utilities
 - **Classes**: PascalCase (Graph, Block, Edge, Port)
 - **Functions**: camelCase (AddBlock, GetSourceBlocks)
@@ -88,6 +100,7 @@ Blocks use **callback functions** with domain-specific syntax:
 - **Interfaces/Types**: PascalCase with Type suffix (BlockStorageType)
 
 ### Code Organization
+
 - **Graph Logic**: `packages/common/src/Graph/`
 - **Network/Storage**: `packages/common/src/Network/GraphItemStorage/`
 - **Default Blocks**: `packages/common/src/DefaultBlocks/` (Constant, Gain, Integrator, Sum, Scope)
@@ -95,7 +108,9 @@ Blocks use **callback functions** with domain-specific syntax:
 - **Redux Store**: `packages/web_app/src/store/`
 
 ### Type Safety Patterns
+
 Uses advanced TypeScript features:
+
 - **Mapped Types**: `MapStringsToPortsType<T>` converts string tuples to port types
 - **Conditional Types**: Port type validation
 - **Generic Constraints**: `Inputs extends PortStringListType`
@@ -104,6 +119,7 @@ Uses advanced TypeScript features:
 ## Build Commands
 
 ### Root Level
+
 ```bash
 npm run clean              # Clean all packages
 npm run bootstrap          # Install and link dependencies
@@ -121,6 +137,7 @@ npm test                   # Run Jest tests
 ```
 
 ### Package-Specific
+
 ```bash
 npx lerna run build --scope=@compx/common
 npx lerna run test --scope=@compx/common --stream
@@ -129,6 +146,7 @@ npx lerna run test --scope=@compx/common --stream
 ## Docker Build Commands
 
 ### Production Web Server (Recommended)
+
 ```bash
 # Build nginx-based web server image
 docker build --target web_server -t compx:latest .
@@ -141,6 +159,7 @@ open http://localhost:8080
 ```
 
 ### Development Server
+
 ```bash
 # Build development image with hot reload
 docker build --target web_dev -t compx:dev .
@@ -153,7 +172,9 @@ docker run -d -p 3000:3000 \
 ```
 
 ### Build Stages
+
 The Dockerfile contains multiple build stages:
+
 - **base**: Foundation with Node 18 Alpine + Python + build tools
 - **loader_builder**: Electron splash screen builder
 - **web_builder_base**: Web app build preparation
@@ -163,6 +184,7 @@ The Dockerfile contains multiple build stages:
 - **electon_builder_linux**: Electron desktop packaging (not needed for Docker)
 
 ### Important Notes
+
 1. **Always use `--target web_server`** for production deployments
 2. **Python + build tools** required for native npm modules (@parcel/watcher)
 3. **Workspace structure**: All dependencies installed centrally via npm workspaces
@@ -175,58 +197,61 @@ See [Docker Guide](../claudedocs/DOCKER.md) for comprehensive Docker documentati
 ### Key Classes
 
 #### Graph
+
 ```typescript
 class Graph {
-  blocks: Block<any, any>[]
-  edges: Edge<any>[]
+  blocks: Block<any, any>[];
+  edges: Edge<any>[];
 
-  AddBlock(block: BlockStorageType): string
-  RemoveBlock(blockId: string): void
-  AddEdge(outputBlockId, outputPortId, inputBlockId, inputPortId): string
-  RemoveEdge(edgeId: string): void
+  AddBlock(block: BlockStorageType): string;
+  RemoveBlock(blockId: string): void;
+  AddEdge(outputBlockId, outputPortId, inputBlockId, inputPortId): string;
+  RemoveEdge(edgeId: string): void;
 
-  GetSourceBlocks(): string[]  // No inputs
-  GetSinkBlocks(): string[]    // No outputs
-  GetAdjacentBlocks(blockId): string[]
+  GetSourceBlocks(): string[]; // No inputs
+  GetSinkBlocks(): string[]; // No outputs
+  GetAdjacentBlocks(blockId): string[];
 
-  DFS(startBlock): string[]
-  SCC(): string[][]             // Strongly connected components
-  ClassifyEdges(): { [edgeId]: EdgeTypes }
-  Transpose(): Graph
+  DFS(startBlock): string[];
+  SCC(): string[][]; // Strongly connected components
+  ClassifyEdges(): { [edgeId]: EdgeTypes };
+  Transpose(): Graph;
 
-  isValidGraph(): boolean
-  GetBlockCompileOrder(): string[]
-  Execute(T: number | 'infinite', dt: number): void
+  isValidGraph(): boolean;
+  GetBlockCompileOrder(): string[];
+  Execute(T: number | 'infinite', dt: number): void;
 }
 ```
 
 #### Block
+
 ```typescript
 class Block<Inputs, Outputs> {
-  id: string
-  name: string
-  description: string
-  tags: string[]
-  inputPorts: Port<Inputs>[]
-  outputPorts: Port<Outputs>[]
-  callbackString: string
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  inputPorts: Port<Inputs>[];
+  outputPorts: Port<Outputs>[];
+  callbackString: string;
 
-  Execute(t, dt, newInputs): void
-  SetCallback(callbackStr): void
-  ChangeInputPortType(portIndex, type, initialValue): Block
-  ChangeOutputPortType(portIndex, type, initialValue): Block
+  Execute(t, dt, newInputs): void;
+  SetCallback(callbackStr): void;
+  ChangeInputPortType(portIndex, type, initialValue): Block;
+  ChangeOutputPortType(portIndex, type, initialValue): Block;
 }
 ```
 
 #### Port Types
+
 ```typescript
 type PortTypes = {
-  'number': number
-  'vector': Vector2D
-  'matrix': Matrix2D
-  'boolean': boolean
-  'string': string
-}
+  number: number;
+  vector: Vector2D;
+  matrix: Matrix2D;
+  boolean: boolean;
+  string: string;
+};
 ```
 
 ### Default Blocks
@@ -240,6 +265,7 @@ type PortTypes = {
 ## State Management (Redux)
 
 ### Store Structure
+
 ```typescript
 {
   graph: {
@@ -255,12 +281,14 @@ type PortTypes = {
 ```
 
 ### Actions
+
 - **Graph Actions**: `ADD_BLOCK`, `REMOVE_BLOCK`, `ADD_EDGE`, `REMOVE_EDGE`
 - **Canvas Actions**: `SET_SCALE`, `SET_POSITION`, zoom/pan controls
 
 ## Common Development Tasks
 
 ### Adding a New Block Type
+
 1. Create block definition in `packages/common/src/DefaultBlocks/`
 2. Define input/output port types
 3. Write callback string with domain syntax
@@ -269,12 +297,14 @@ type PortTypes = {
 6. Add UI component in web_app if needed
 
 ### Modifying Graph Algorithm
+
 1. Update logic in `packages/common/src/Graph/Graph.ts`
 2. Add/update tests in `packages/common/__tests__/`
 3. Ensure algorithm maintains graph invariants
 4. Update compile order if execution affected
 
 ### UI Component Development
+
 1. Create component in `packages/web_app/src/app/Container/`
 2. Use React-Konva for canvas elements
 3. Connect to Redux with hooks (`useSelector`, `useDispatch`)
@@ -283,12 +313,14 @@ type PortTypes = {
 ## Testing
 
 ### Test Structure
+
 - Unit tests in `__tests__` directories within packages
 - Test resources in `__tests__/Resources/`
 - Jest configuration per package
 - Coverage reporting enabled
 
 ### Running Tests
+
 ```bash
 npm test                           # All tests
 npm test -- --watch               # Watch mode
@@ -298,6 +330,7 @@ npm test -- packages/common       # Specific package
 ## Important Constraints
 
 ### Graph Validity Rules
+
 1. Each strongly connected component must have ≥1 source or pseudo-source
 2. Maximum one edge per input port
 3. Port types must match for connections
@@ -305,6 +338,7 @@ npm test -- packages/common       # Specific package
 5. Compile order must be computable (no invalid cycles)
 
 ### Performance Considerations
+
 - **Graph Size**: Algorithms are O(V+E), suitable for moderate graphs
 - **Execution**: Synchronous per time step
 - **UI Rendering**: React-Konva uses canvas, scales to ~1000 elements
@@ -312,17 +346,20 @@ npm test -- packages/common       # Specific package
 ## Debugging Tips
 
 ### Graph Execution Issues
+
 - Check `GetBlockCompileOrder()` for correct topological sort
 - Verify `isValidGraph()` returns true
 - Inspect `ClassifyEdges()` for back edges (feedback loops)
 - Use `SCC()` to identify strongly connected components
 
 ### Type Errors
+
 - Port type mismatches: Check `PortTypes` definitions
 - Generic constraints: Ensure `PortStringListType` compliance
 - Storage conversions: Verify ToStorage/FromStorage symmetry
 
 ### Build Issues
+
 - Clear with `npm run clean` then `npm run bootstrap`
 - Check Lerna linking: `npx lerna link`
 - Verify TypeScript compilation in each package separately
@@ -330,6 +367,7 @@ npm test -- packages/common       # Specific package
 ## Future Development Areas
 
 ### Potential Enhancements
+
 - **Asynchronous Execution**: Worker threads for large graphs
 - **Custom Block Editor**: Visual callback editor instead of strings
 - **Graph Persistence**: Save/load graph files
@@ -338,6 +376,7 @@ npm test -- packages/common       # Specific package
 - **Advanced Visualizations**: Scope block improvements, data plotting
 
 ### Known Limitations
+
 - Callback strings use `eval`-based Function constructor (security consideration)
 - No runtime type checking during execution
 - Limited error recovery during graph execution
@@ -346,6 +385,7 @@ npm test -- packages/common       # Specific package
 ## Working with Claude Code
 
 ### Best Practices
+
 1. **Search Strategy**: Use Serena MCP for symbol navigation in large TypeScript codebase
 2. **Graph Operations**: Reference Graph.ts:line_number for algorithm implementations
 3. **Type Modifications**: Understand mapped types before changing port definitions
@@ -353,6 +393,7 @@ npm test -- packages/common       # Specific package
 5. **Build Verification**: Test both web and electron builds for cross-platform changes
 
 ### Common Queries
+
 - "Find all references to Block class" → Use Serena find_symbol
 - "Explain SCC algorithm" → Reference Graph.ts:261-318
 - "Add new port type" → Modify Port.ts type definitions + update all type maps
@@ -361,17 +402,20 @@ npm test -- packages/common       # Specific package
 ## Project Maintenance
 
 ### Dependency Updates
+
 - Major updates: Test thoroughly across all packages
 - Minor updates: Run full test suite
 - Security patches: Prioritize and validate
 
 ### Code Quality Standards
+
 - ESLint: Airbnb config with TypeScript extensions
 - Prettier: Consistent formatting
 - Pre-commit hooks: Enforce quality before commits
 - Type coverage: Maintain strict TypeScript compliance
 
 ### Documentation Standards
+
 - JSDoc for public APIs
 - Inline comments for complex algorithms
 - README updates for new features

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,10 +36,7 @@
     "import/no-dynamic-require": "warn",
     "no-bitwise": "off",
     "import/no-cycle": "off",
-    "max-classes-per-file": [
-      "error",
-      { "ignoreExpressions": true, "max": 2 }
-    ],
+    "max-classes-per-file": ["error", { "ignoreExpressions": true, "max": 2 }],
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx eslint --ignore-path .gitignore packages/web_app/webpack/webpack.common.js
+npx lint-staged

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -7,7 +7,7 @@ language: typescript
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
-encoding: "utf-8"
+encoding: 'utf-8'
 
 # whether to use the project's gitignore file to ignore files
 # Added on 2025-04-07
@@ -25,7 +25,7 @@ read_only: false
 
 # list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
 # Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
+# To make sure you have the latest list of tools, and to view their descriptions,
 # execute `uv run scripts/print_tool_overview.py`.
 #
 #  * `activate_project`: Activates a project by name.
@@ -66,6 +66,6 @@ excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
-initial_prompt: ""
+initial_prompt: ''
 
-project_name: "CompX"
+project_name: 'CompX'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <a id="readme-top"></a>
 
 <!-- PROJECT SHIELDS -->
+
 [![Contributors][contributors-shield]][contributors-url]
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
@@ -60,6 +61,7 @@
 </details>
 
 <!-- ABOUT THE PROJECT -->
+
 ## About The Project
 
 [![CompX Screenshot][product-screenshot]](https://github.com/aidanpetti/CompX)
@@ -68,32 +70,36 @@
 
 ### Core Capabilities
 
-* **Visual Block Programming**: Drag-and-drop interface for building computational graphs
-* **Graph Execution Engine**: Advanced DFS-based compilation with SCC detection and topological sorting
-* **Multi-Platform Support**: Web application and Electron desktop application
-* **Real-Time Simulation**: Continuous and discrete-time execution with visualization
-* **Type-Safe Architecture**: Strongly-typed port system ensuring connection validity
+- **Visual Block Programming**: Drag-and-drop interface for building computational graphs
+- **Graph Execution Engine**: Advanced DFS-based compilation with SCC detection and topological sorting
+- **Multi-Platform Support**: Web application and Electron desktop application
+- **Real-Time Simulation**: Continuous and discrete-time execution with visualization
+- **Type-Safe Architecture**: Strongly-typed port system ensuring connection validity
 
 ### Key Features
 
 🎯 **Intelligent Graph Compilation**
+
 - Automatic topological sort for execution order
 - Strongly connected component detection (Kosaraju's algorithm)
 - Edge classification (tree, back, forward, cross)
 - Graph validation ensuring executable structure
 
 🔧 **Extensible Block System**
+
 - Built-in blocks: Constant, Gain, Sum, Integrator, Scope
 - Custom block creation with domain-specific syntax
 - Type-safe ports (number, vector, matrix, boolean, string)
 - Pseudo-source blocks for feedback loops
 
 ⚡ **High Performance**
+
 - O(V+E) graph algorithms
 - Efficient canvas-based visualization with React-Konva
 - Optimized execution engine for large graphs
 
 🏗️ **Monorepo Architecture**
+
 - Lerna-managed multi-package structure
 - Shared core engine across platforms
 - Independent package development and testing
@@ -104,28 +110,29 @@
 
 **Core Technologies**
 
-* [![TypeScript][TypeScript.badge]][TypeScript-url]
-* [![React][React.js]][React-url]
-* [![Redux][Redux.badge]][Redux-url]
-* [![Electron][Electron.badge]][Electron-url]
+- [![TypeScript][TypeScript.badge]][TypeScript-url]
+- [![React][React.js]][React-url]
+- [![Redux][Redux.badge]][Redux-url]
+- [![Electron][Electron.badge]][Electron-url]
 
 **Key Libraries**
 
-* **React-Konva**: Canvas-based graph visualization
-* **Bootstrap 5**: UI components and styling
-* **Lerna**: Monorepo management
-* **Jest**: Testing framework
-* **Webpack 5**: Build system
+- **React-Konva**: Canvas-based graph visualization
+- **Bootstrap 5**: UI components and styling
+- **Lerna**: Monorepo management
+- **Jest**: Testing framework
+- **Webpack 5**: Build system
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- GETTING STARTED -->
+
 ## Getting Started
 
 ### Prerequisites
 
-* **Node.js** 16.x or later
-* **npm** 8.x or later
+- **Node.js** 16.x or later
+- **npm** 8.x or later
   ```sh
   npm install npm@latest -g
   ```
@@ -133,17 +140,20 @@
 ### Installation
 
 1. Clone the repository
+
    ```sh
    git clone https://github.com/aidanpetti/CompX.git
    cd CompX
    ```
 
 2. Install dependencies
+
    ```sh
    npm install
    ```
 
 3. Bootstrap packages (Lerna)
+
    ```sh
    npm run bootstrap
    ```
@@ -158,17 +168,21 @@
 ### Quick Start
 
 **Launch Web Application**
+
 ```sh
 npm run web:start
 ```
+
 Open browser to `http://localhost:3000`
 
 **Launch Electron Application**
+
 ```sh
 npm run electron:start
 ```
 
 **Build for Production**
+
 ```sh
 # Web application
 npm run web:build
@@ -178,6 +192,7 @@ npm run electron:build
 ```
 
 **Docker Deployment**
+
 ```sh
 # Build web server image
 docker build --target web_server -t compx:latest .
@@ -185,6 +200,7 @@ docker build --target web_server -t compx:latest .
 # Run container
 docker run -p 8080:80 compx:latest
 ```
+
 Open browser to `http://localhost:8080`
 
 For detailed setup and development workflows, see the [Quick Start Guide](claudedocs/QUICK_START.md).
@@ -193,34 +209,35 @@ For Docker deployment and configuration, see the [Docker Guide](claudedocs/DOCKE
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- USAGE EXAMPLES -->
+
 ## Usage
 
 ### Creating Your First Graph
 
 ```typescript
-import { Graph } from '@compx/common'
-import { Constant, Gain, Scope } from '@compx/common'
+import { Graph } from '@compx/common';
+import { Constant, Gain, Scope } from '@compx/common';
 
 // Create empty graph
-const graph = new Graph({ blocks: [], edges: [] })
+const graph = new Graph({ blocks: [], edges: [] });
 
 // Add blocks
-const constantId = graph.AddBlock(Constant)  // Source: outputs constant value
-const gainId = graph.AddBlock(Gain)          // Multiplier
-const scopeId = graph.AddBlock(Scope)        // Visualization sink
+const constantId = graph.AddBlock(Constant); // Source: outputs constant value
+const gainId = graph.AddBlock(Gain); // Multiplier
+const scopeId = graph.AddBlock(Scope); // Visualization sink
 
 // Connect blocks
-graph.AddEdge(constantId, 'value', gainId, 'in')
-graph.AddEdge(gainId, 'out', scopeId, 'in')
+graph.AddEdge(constantId, 'value', gainId, 'in');
+graph.AddEdge(gainId, 'out', scopeId, 'in');
 
 // Execute simulation (10 seconds, 0.01s time step)
-graph.Execute(10.0, 0.01)
+graph.Execute(10.0, 0.01);
 ```
 
 ### Creating a Custom Block
 
 ```typescript
-import { BlockStorageType } from '@compx/common'
+import { BlockStorageType } from '@compx/common';
 
 export const Multiplier: BlockStorageType<['in1', 'in2'], ['out']> = {
   name: 'Multiplier',
@@ -230,37 +247,37 @@ export const Multiplier: BlockStorageType<['in1', 'in2'], ['out']> = {
     { name: 'in1', type: 'number' },
     { name: 'in2', type: 'number' }
   ],
-  outputPorts: [
-    { name: 'out', type: 'number' }
-  ],
+  outputPorts: [{ name: 'out', type: 'number' }],
   callbackString: 'return [inputPort[in1] * inputPort[in2]];'
-}
+};
 ```
 
 ### Advanced Features
 
 **Feedback Loops with Integrator**
+
 ```typescript
 // Integrator uses previous output as state
-const integratorId = graph.AddBlock(Integrator)
+const integratorId = graph.AddBlock(Integrator);
 
 // Create feedback loop
-graph.AddEdge(gainId, 'out', integratorId, 'in')
-graph.AddEdge(integratorId, 'out', gainId, 'in')  // Feedback!
+graph.AddEdge(gainId, 'out', integratorId, 'in');
+graph.AddEdge(integratorId, 'out', gainId, 'in'); // Feedback!
 ```
 
 **Graph Validation**
+
 ```typescript
 // Check if graph is valid (all SCCs have sources)
 if (!graph.isValidGraph()) {
-  console.error('Invalid graph structure')
-  console.log('Components:', graph.SCC())
-  console.log('Sources:', graph.GetSourceBlocks())
+  console.error('Invalid graph structure');
+  console.log('Components:', graph.SCC());
+  console.log('Sources:', graph.GetSourceBlocks());
 }
 
 // Get execution order
-const compileOrder = graph.GetBlockCompileOrder()
-console.log('Execution order:', compileOrder)
+const compileOrder = graph.GetBlockCompileOrder();
+console.log('Execution order:', compileOrder);
 ```
 
 _For more examples and API documentation, please refer to the [API Reference](claudedocs/API_REFERENCE.md)_
@@ -268,6 +285,7 @@ _For more examples and API documentation, please refer to the [API Reference](cl
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- ARCHITECTURE -->
+
 ## Architecture
 
 CompX uses a **monorepo structure** managed by Lerna with four main packages:
@@ -284,39 +302,44 @@ CompX/
 ### Core Components
 
 **Graph Engine** (`@compx/common`)
+
 - Graph data structure with blocks, edges, and ports
 - Advanced algorithms: DFS, SCC (Kosaraju), topological sort
 - Type-safe port system with generic constraints
 - Block execution engine with callback system
 
 **Web Application** (`@compx/web_app`)
+
 - React 18 + Redux Toolkit for state management
 - React-Konva for canvas-based visualization
 - Bootstrap 5 UI components
 - Webpack dev server with HMR
 
 **Desktop Application** (`@compx/electron_app`)
+
 - Electron wrapper for cross-platform desktop
 - Custom window management
 - Bundles web_app as renderer process
 
 ### Key Algorithms
 
-| Algorithm | Complexity | Purpose |
-|-----------|-----------|---------|
-| **DFS** | O(V + E) | Graph traversal and reachability |
-| **SCC (Kosaraju)** | O(V + E) | Detect feedback loops, validate structure |
-| **Topological Sort** | O(V + E) | Compute execution order |
-| **Edge Classification** | O(V + E) | Identify structural patterns |
+| Algorithm               | Complexity | Purpose                                   |
+| ----------------------- | ---------- | ----------------------------------------- |
+| **DFS**                 | O(V + E)   | Graph traversal and reachability          |
+| **SCC (Kosaraju)**      | O(V + E)   | Detect feedback loops, validate structure |
+| **Topological Sort**    | O(V + E)   | Compute execution order                   |
+| **Edge Classification** | O(V + E)   | Identify structural patterns              |
 
 _For detailed architecture documentation, see [ARCHITECTURE.md](claudedocs/ARCHITECTURE.md)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- ROADMAP -->
+
 ## Roadmap
 
 ### Current Features ✅
+
 - [x] Core graph engine with advanced algorithms
 - [x] Type-safe block and port system
 - [x] Web and Electron applications
@@ -327,6 +350,7 @@ _For detailed architecture documentation, see [ARCHITECTURE.md](claudedocs/ARCHI
 ### Planned Enhancements 🚀
 
 #### Short-Term
+
 - [ ] Graph save/load functionality
 - [ ] Custom block editor UI
 - [ ] Additional mathematical blocks (Derivative, Transfer Function)
@@ -335,6 +359,7 @@ _For detailed architecture documentation, see [ARCHITECTURE.md](claudedocs/ARCHI
 - [ ] Undo/redo functionality
 
 #### Medium-Term
+
 - [ ] Performance profiling per block
 - [ ] Asynchronous execution with Web Workers
 - [ ] Real-time collaboration (multi-user)
@@ -342,6 +367,7 @@ _For detailed architecture documentation, see [ARCHITECTURE.md](claudedocs/ARCHI
 - [ ] Advanced visualization (3D, animations)
 
 #### Long-Term
+
 - [ ] Code generation from graphs (C++, Python)
 - [ ] Hardware-in-the-loop simulation
 - [ ] Cloud-based execution
@@ -352,6 +378,7 @@ See the [open issues](https://github.com/aidanpetti/CompX/issues) for a full lis
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTRIBUTING -->
+
 ## Contributing
 
 Contributions make the open source community an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
@@ -382,6 +409,7 @@ See the [Development Guide](claudedocs/DEVELOPMENT_GUIDE.md) for detailed workfl
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- LICENSE -->
+
 ## License
 
 Distributed under the ISC License. See `LICENSE.txt` for more information.
@@ -389,6 +417,7 @@ Distributed under the ISC License. See `LICENSE.txt` for more information.
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTACT -->
+
 ## Contact
 
 **Aidan Petti** - [@aidanpetti](https://twitter.com/aidanpetti)
@@ -400,32 +429,34 @@ Distributed under the ISC License. See `LICENSE.txt` for more information.
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- ACKNOWLEDGMENTS -->
+
 ## Acknowledgments
 
 ### Technologies & Libraries
 
-* [React](https://reactjs.org/) - UI framework
-* [Redux Toolkit](https://redux-toolkit.js.org/) - State management
-* [React-Konva](https://konvajs.org/docs/react/) - Canvas visualization
-* [TypeScript](https://www.typescriptlang.org/) - Type safety
-* [Lerna](https://lerna.js.org/) - Monorepo management
-* [Electron](https://www.electronjs.org/) - Desktop application
-* [Bootstrap](https://getbootstrap.com/) - UI components
-* [Jest](https://jestjs.io/) - Testing framework
+- [React](https://reactjs.org/) - UI framework
+- [Redux Toolkit](https://redux-toolkit.js.org/) - State management
+- [React-Konva](https://konvajs.org/docs/react/) - Canvas visualization
+- [TypeScript](https://www.typescriptlang.org/) - Type safety
+- [Lerna](https://lerna.js.org/) - Monorepo management
+- [Electron](https://www.electronjs.org/) - Desktop application
+- [Bootstrap](https://getbootstrap.com/) - UI components
+- [Jest](https://jestjs.io/) - Testing framework
 
 ### Algorithms & Computer Science
 
-* Kosaraju's Algorithm for Strongly Connected Components
-* Topological Sorting for DAG execution
-* Depth-First Search for graph traversal
+- Kosaraju's Algorithm for Strongly Connected Components
+- Topological Sorting for DAG execution
+- Depth-First Search for graph traversal
 
 ### Documentation Template
 
-* [Best-README-Template](https://github.com/othneildrew/Best-README-Template)
+- [Best-README-Template](https://github.com/othneildrew/Best-README-Template)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->
+
 [contributors-shield]: https://img.shields.io/github/contributors/aidanpetti/CompX.svg?style=for-the-badge
 [contributors-url]: https://github.com/aidanpetti/CompX/graphs/contributors
 [forks-shield]: https://img.shields.io/github/forks/aidanpetti/CompX.svg?style=for-the-badge
@@ -437,7 +468,6 @@ Distributed under the ISC License. See `LICENSE.txt` for more information.
 [license-shield]: https://img.shields.io/github/license/aidanpetti/CompX.svg?style=for-the-badge
 [license-url]: https://github.com/aidanpetti/CompX/blob/master/LICENSE.txt
 [product-screenshot]: assets/screenshot.png
-
 [TypeScript.badge]: https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white
 [TypeScript-url]: https://www.typescriptlang.org/
 [React.js]: https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB

--- a/claudedocs/API_REFERENCE.md
+++ b/claudedocs/API_REFERENCE.md
@@ -15,9 +15,11 @@ constructor(graph: GraphStorageType)
 ```
 
 **Parameters**:
+
 - `graph`: Serialized graph structure containing blocks and edges
 
 **Example**:
+
 ```typescript
 const graph = new Graph({
   blocks: [...],
@@ -28,6 +30,7 @@ const graph = new Graph({
 #### Block Management Methods
 
 ##### AddBlock()
+
 ```typescript
 AddBlock(block: BlockStorageType<PortStringListType, PortStringListType>): string
 ```
@@ -35,6 +38,7 @@ AddBlock(block: BlockStorageType<PortStringListType, PortStringListType>): strin
 **Purpose**: Add a new block to the graph
 
 **Parameters**:
+
 - `block`: Block storage definition (name, ports, callback)
 
 **Returns**: UUID of newly created block
@@ -42,6 +46,7 @@ AddBlock(block: BlockStorageType<PortStringListType, PortStringListType>): strin
 **Throws**: None (block creation always succeeds)
 
 **Example**:
+
 ```typescript
 const blockId = graph.AddBlock({
   name: 'Gain',
@@ -50,10 +55,11 @@ const blockId = graph.AddBlock({
   inputPorts: [{ name: 'in', type: 'number' }],
   outputPorts: [{ name: 'out', type: 'number' }],
   callbackString: 'return [inputPort[in] * 2]'
-})
+});
 ```
 
 ##### RemoveBlock()
+
 ```typescript
 RemoveBlock(blockId: string): void | never
 ```
@@ -61,6 +67,7 @@ RemoveBlock(blockId: string): void | never
 **Purpose**: Remove block and connected edges from graph
 
 **Parameters**:
+
 - `blockId`: UUID of block to remove
 
 **Throws**: `CompXError` if block not found
@@ -68,13 +75,15 @@ RemoveBlock(blockId: string): void | never
 **Side Effects**: Removes all edges connected to this block
 
 **Example**:
+
 ```typescript
-graph.RemoveBlock('uuid-of-block')
+graph.RemoveBlock('uuid-of-block');
 ```
 
 #### Edge Management Methods
 
 ##### AddEdge()
+
 ```typescript
 AddEdge(
   outputBlockId: string,
@@ -87,6 +96,7 @@ AddEdge(
 **Purpose**: Create typed connection between blocks
 
 **Parameters**:
+
 - `outputBlockId`: Source block UUID
 - `outputPortId`: Source port name
 - `inputBlockId`: Destination block UUID
@@ -95,6 +105,7 @@ AddEdge(
 **Returns**: UUID of edge (existing if duplicate, new otherwise)
 
 **Validation**:
+
 - ✓ Both blocks exist
 - ✓ Both ports exist
 - ✓ Port types match
@@ -102,14 +113,18 @@ AddEdge(
 - ✗ Throws `CompXError` on validation failure
 
 **Example**:
+
 ```typescript
 const edgeId = graph.AddEdge(
-  constantBlockId, 'value',  // output
-  gainBlockId, 'in'          // input
-)
+  constantBlockId,
+  'value', // output
+  gainBlockId,
+  'in' // input
+);
 ```
 
 ##### RemoveEdge()
+
 ```typescript
 RemoveEdge(edgeId: string): void | never
 ```
@@ -119,13 +134,15 @@ RemoveEdge(edgeId: string): void | never
 **Throws**: `CompXError` if edge not found
 
 **Example**:
+
 ```typescript
-graph.RemoveEdge('uuid-of-edge')
+graph.RemoveEdge('uuid-of-edge');
 ```
 
 #### Graph Query Methods
 
 ##### GetSourceBlocks()
+
 ```typescript
 GetSourceBlocks(): string[]
 ```
@@ -137,12 +154,14 @@ GetSourceBlocks(): string[]
 **Definition**: Source = no input ports OR uses `prevInput[]`/`prevOutput[]`
 
 **Example**:
+
 ```typescript
-const sources = graph.GetSourceBlocks()
+const sources = graph.GetSourceBlocks();
 // ['constant-uuid', 'integrator-uuid']
 ```
 
 ##### GetSinkBlocks()
+
 ```typescript
 GetSinkBlocks(): string[]
 ```
@@ -152,12 +171,14 @@ GetSinkBlocks(): string[]
 **Returns**: Array of block UUIDs
 
 **Example**:
+
 ```typescript
-const sinks = graph.GetSinkBlocks()
+const sinks = graph.GetSinkBlocks();
 // ['scope-uuid', 'output-uuid']
 ```
 
 ##### GetAdjacentBlocks()
+
 ```typescript
 GetAdjacentBlocks(blockId: string): string[]
 ```
@@ -167,14 +188,16 @@ GetAdjacentBlocks(blockId: string): string[]
 **Returns**: Array of block UUIDs connected to outputs
 
 **Example**:
+
 ```typescript
-const adjacentBlocks = graph.GetAdjacentBlocks(gainBlockId)
+const adjacentBlocks = graph.GetAdjacentBlocks(gainBlockId);
 // ['sum-uuid', 'scope-uuid']
 ```
 
 #### Graph Algorithm Methods
 
 ##### DFS()
+
 ```typescript
 DFS(startBlock: string): string[]
 ```
@@ -188,12 +211,14 @@ DFS(startBlock: string): string[]
 **Complexity**: O(V + E)
 
 **Example**:
+
 ```typescript
-const reachableBlocks = graph.DFS(constantBlockId)
+const reachableBlocks = graph.DFS(constantBlockId);
 // ['constant-uuid', 'gain-uuid', 'sum-uuid', 'scope-uuid']
 ```
 
 ##### SCC()
+
 ```typescript
 SCC(): string[][]
 ```
@@ -201,6 +226,7 @@ SCC(): string[][]
 **Purpose**: Find strongly connected components using Kosaraju's algorithm
 
 **Algorithm**:
+
 1. DFS to find finish times
 2. Transpose graph
 3. DFS on transpose in reverse finish order
@@ -210,8 +236,9 @@ SCC(): string[][]
 **Complexity**: O(V + E)
 
 **Example**:
+
 ```typescript
-const components = graph.SCC()
+const components = graph.SCC();
 // [
 //   ['integrator-uuid', 'feedback-gain-uuid'],  // Feedback loop
 //   ['constant-uuid'],
@@ -220,6 +247,7 @@ const components = graph.SCC()
 ```
 
 ##### ClassifyEdges()
+
 ```typescript
 ClassifyEdges(): { [edgeId: string]: EdgeTypes }
 ```
@@ -231,14 +259,16 @@ ClassifyEdges(): { [edgeId: string]: EdgeTypes }
 **Returns**: Map of edge UUID to edge type
 
 **Edge Types**:
+
 - `TREE`: DFS tree edge (parent → child)
 - `BACK`: Feedback edge (descendant → ancestor)
 - `FORWARD`: Shortcut edge (ancestor → descendant, non-tree)
 - `CROSS`: Between different DFS subtrees
 
 **Example**:
+
 ```typescript
-const edgeTypes = graph.ClassifyEdges()
+const edgeTypes = graph.ClassifyEdges();
 // {
 //   'edge-1-uuid': 'TREE',
 //   'edge-2-uuid': 'BACK',   // Feedback loop
@@ -247,6 +277,7 @@ const edgeTypes = graph.ClassifyEdges()
 ```
 
 ##### Transpose()
+
 ```typescript
 Transpose(): Graph
 ```
@@ -258,13 +289,15 @@ Transpose(): Graph
 **Side Effects**: Clears callbacks (invalid after port swap)
 
 **Example**:
+
 ```typescript
-const reversedGraph = graph.Transpose()
+const reversedGraph = graph.Transpose();
 ```
 
 #### Graph Validation Methods
 
 ##### isValidGraph()
+
 ```typescript
 isValidGraph(): boolean
 ```
@@ -276,13 +309,15 @@ isValidGraph(): boolean
 **Returns**: `true` if valid, `false` otherwise
 
 **Example**:
+
 ```typescript
 if (!graph.isValidGraph()) {
-  throw new Error('Graph has unreachable components')
+  throw new Error('Graph has unreachable components');
 }
 ```
 
 ##### GetBlockCompileOrder()
+
 ```typescript
 GetBlockCompileOrder(): string[]
 ```
@@ -294,6 +329,7 @@ GetBlockCompileOrder(): string[]
 **Returns**: Array of block UUIDs in execution order
 
 **Guarantees**:
+
 - All inputs satisfied before execution
 - Sinks appear at end
 - Respects data dependencies
@@ -301,14 +337,16 @@ GetBlockCompileOrder(): string[]
 **Complexity**: O(V + E)
 
 **Example**:
+
 ```typescript
-const compileOrder = graph.GetBlockCompileOrder()
+const compileOrder = graph.GetBlockCompileOrder();
 // ['constant-uuid', 'gain-uuid', 'sum-uuid', 'scope-uuid']
 ```
 
 #### Execution Methods
 
 ##### Execute()
+
 ```typescript
 Execute(T: number | 'infinite', dt: number): void
 ```
@@ -316,10 +354,12 @@ Execute(T: number | 'infinite', dt: number): void
 **Purpose**: Run time-stepped simulation
 
 **Parameters**:
+
 - `T`: Total simulation time OR `'infinite'` for continuous
 - `dt`: Time step size
 
 **Algorithm**:
+
 ```
 for t = 0 to T step dt:
   for block in compileOrder:
@@ -329,17 +369,19 @@ for t = 0 to T step dt:
 ```
 
 **Example**:
+
 ```typescript
 // Simulate for 10 seconds with 0.01s time step
-graph.Execute(10.0, 0.01)
+graph.Execute(10.0, 0.01);
 
 // Continuous simulation (manual stop required)
-graph.Execute('infinite', 0.01)
+graph.Execute('infinite', 0.01);
 ```
 
 #### Serialization Methods
 
 ##### ToStorage()
+
 ```typescript
 ToStorage(): GraphStorageType
 ```
@@ -349,9 +391,10 @@ ToStorage(): GraphStorageType
 **Returns**: Plain object with block/edge storage
 
 **Example**:
+
 ```typescript
-const storage = graph.ToStorage()
-localStorage.setItem('graph', JSON.stringify(storage))
+const storage = graph.ToStorage();
+localStorage.setItem('graph', JSON.stringify(storage));
 ```
 
 ---
@@ -367,6 +410,7 @@ Blocks created via static factory methods, not direct construction
 ### Static Factory Methods
 
 ##### InitializeFromStorage()
+
 ```typescript
 static InitializeFromStorage<Inputs, Outputs>(
   blockStorage: BlockStorageType<Inputs, Outputs>
@@ -380,6 +424,7 @@ static InitializeFromStorage<Inputs, Outputs>(
 **Returns**: Block instance with new UUID
 
 ##### InitializeFromStorageWithId()
+
 ```typescript
 static InitializeFromStorageWithId<Inputs, Outputs>(
   blockStorage: BlockStorageWithIDType<Inputs, Outputs>
@@ -395,6 +440,7 @@ static InitializeFromStorageWithId<Inputs, Outputs>(
 ### Instance Methods
 
 ##### SetCallback()
+
 ```typescript
 SetCallback(callbackStr: string): void
 ```
@@ -402,20 +448,23 @@ SetCallback(callbackStr: string): void
 **Purpose**: Set/update block's computational callback
 
 **Callback Syntax**:
+
 - `inputPort[name]` → Current input value
 - `prevInput[name]` → Previous input (makes pseudo-source)
 - `prevOutput[name]` → Previous output value
 - `initialCondition[name]` → Initial value for port
 
 **Example**:
+
 ```typescript
 block.SetCallback(`
   const sum = inputPort[in1] + inputPort[in2];
   return [sum];
-`)
+`);
 ```
 
 ##### Execute()
+
 ```typescript
 Execute(t: number, dt: number, newInputs: MapStringsToTypes<Inputs>): void
 ```
@@ -423,6 +472,7 @@ Execute(t: number, dt: number, newInputs: MapStringsToTypes<Inputs>): void
 **Purpose**: Execute block for one time step
 
 **Parameters**:
+
 - `t`: Current simulation time
 - `dt`: Time step duration
 - `newInputs`: Array of input values in port order
@@ -430,11 +480,13 @@ Execute(t: number, dt: number, newInputs: MapStringsToTypes<Inputs>): void
 **Side Effects**: Updates output port values
 
 **Example**:
+
 ```typescript
-block.Execute(0.5, 0.01, [10, 20])  // Two inputs
+block.Execute(0.5, 0.01, [10, 20]); // Two inputs
 ```
 
 ##### ChangeInputPortType()
+
 ```typescript
 ChangeInputPortType<I, U>(
   portIndex: I,
@@ -448,11 +500,13 @@ ChangeInputPortType<I, U>(
 **Type Safety**: Return type reflects new port configuration
 
 **Example**:
+
 ```typescript
-const newBlock = block.ChangeInputPortType(0, 'vector', new Vector2D(0, 0))
+const newBlock = block.ChangeInputPortType(0, 'vector', new Vector2D(0, 0));
 ```
 
 ##### ChangeOutputPortType()
+
 ```typescript
 ChangeOutputPortType<I, U>(
   portIndex: I,
@@ -464,11 +518,13 @@ ChangeOutputPortType<I, U>(
 **Purpose**: Change output port type
 
 **Example**:
+
 ```typescript
-const newBlock = block.ChangeOutputPortType(0, 'matrix')
+const newBlock = block.ChangeOutputPortType(0, 'matrix');
 ```
 
 ##### ToStorage()
+
 ```typescript
 ToStorage(): BlockStorageWithIDType<Inputs, Outputs>
 ```
@@ -485,17 +541,18 @@ ToStorage(): BlockStorageWithIDType<Inputs, Outputs>
 
 ```typescript
 type PortTypes = {
-  'number': number
-  'vector': Vector2D
-  'matrix': Matrix2D
-  'boolean': boolean
-  'string': string
-}
+  number: number;
+  vector: Vector2D;
+  matrix: Matrix2D;
+  boolean: boolean;
+  string: string;
+};
 ```
 
 ### Methods
 
 ##### GetObjectValue()
+
 ```typescript
 GetObjectValue(): PortTypes[T]
 ```
@@ -503,6 +560,7 @@ GetObjectValue(): PortTypes[T]
 **Purpose**: Get current port value (typed)
 
 ##### SetValue()
+
 ```typescript
 SetValue(value: PortTypes[T]): void
 ```
@@ -510,6 +568,7 @@ SetValue(value: PortTypes[T]): void
 **Purpose**: Update port value (typed)
 
 ##### GetPortResetType()
+
 ```typescript
 GetPortResetType<U>(type: U, initialValue?: PortTypes[U]): Port<U>
 ```
@@ -525,17 +584,17 @@ GetPortResetType<U>(type: U, initialValue?: PortTypes[U]): Port<U>
 ### Edge Types
 
 ```typescript
-type EdgeTypes = 'TREE' | 'BACK' | 'FORWARD' | 'CROSS'
+type EdgeTypes = 'TREE' | 'BACK' | 'FORWARD' | 'CROSS';
 ```
 
 ### Structure
 
 ```typescript
 class Edge<T extends keyof PortTypes> {
-  id: string
-  type: T
-  output: { blockID: string, portID: string }
-  input: { blockID: string, portID: string }
+  id: string;
+  type: T;
+  output: { blockID: string; portID: string };
+  input: { blockID: string; portID: string };
 }
 ```
 
@@ -591,21 +650,14 @@ class Edge<T extends keyof PortTypes> {
 
 ```typescript
 class CompXError extends Error {
-  constructor(
-    level: 'error' | 'warning',
-    title: string,
-    message: string
-  )
+  constructor(level: 'error' | 'warning', title: string, message: string);
 }
 ```
 
 **Usage**:
+
 ```typescript
-throw new CompXError(
-  'warning',
-  'Port Type Mismatch',
-  `Cannot connect ${outputType} to ${inputType}`
-)
+throw new CompXError('warning', 'Port Type Mismatch', `Cannot connect ${outputType} to ${inputType}`);
 ```
 
 ---
@@ -618,38 +670,38 @@ throw new CompXError(
 
 ```typescript
 // Add block to graph
-dispatch({ type: 'ADD_BLOCK', payload: blockStorage })
+dispatch({ type: 'ADD_BLOCK', payload: blockStorage });
 
 // Remove block from graph
-dispatch({ type: 'REMOVE_BLOCK', payload: blockId })
+dispatch({ type: 'REMOVE_BLOCK', payload: blockId });
 
 // Add edge connection
 dispatch({
   type: 'ADD_EDGE',
   payload: { outputBlockId, outputPortId, inputBlockId, inputPortId }
-})
+});
 
 // Remove edge connection
-dispatch({ type: 'REMOVE_EDGE', payload: edgeId })
+dispatch({ type: 'REMOVE_EDGE', payload: edgeId });
 
 // Update compile order
-dispatch({ type: 'UPDATE_COMPILE_ORDER' })
+dispatch({ type: 'UPDATE_COMPILE_ORDER' });
 ```
 
 ### Canvas Actions
 
 ```typescript
 // Set zoom level
-dispatch({ type: 'SET_SCALE', payload: scale })
+dispatch({ type: 'SET_SCALE', payload: scale });
 
 // Set pan position
-dispatch({ type: 'SET_POSITION', payload: { x, y } })
+dispatch({ type: 'SET_POSITION', payload: { x, y } });
 
 // Select blocks
-dispatch({ type: 'SELECT_BLOCKS', payload: blockIds })
+dispatch({ type: 'SELECT_BLOCKS', payload: blockIds });
 
 // Select edges
-dispatch({ type: 'SELECT_EDGES', payload: edgeIds })
+dispatch({ type: 'SELECT_EDGES', payload: edgeIds });
 ```
 
 ---
@@ -659,6 +711,7 @@ dispatch({ type: 'SELECT_EDGES', payload: edgeIds })
 **Location**: `packages/common/src/Helpers/Types.ts`
 
 ### ReplaceInTuple
+
 ```typescript
 type ReplaceInTuple<Tuple, Index, NewType>
 ```
@@ -666,8 +719,9 @@ type ReplaceInTuple<Tuple, Index, NewType>
 **Purpose**: Replace element at index in tuple type
 
 **Example**:
+
 ```typescript
-ReplaceInTuple<['number', 'vector'], 1, 'matrix'>
+ReplaceInTuple<['number', 'vector'], 1, 'matrix'>;
 // → ['number', 'matrix']
 ```
 

--- a/claudedocs/ARCHITECTURE.md
+++ b/claudedocs/ARCHITECTURE.md
@@ -49,6 +49,7 @@ CompX is a **visual computational graph system** that enables users to build, ex
 **Purpose**: Platform-independent graph computation engine
 
 **Key Modules**:
+
 - **Graph/**: Core graph data structures and algorithms
 - **DefaultBlocks/**: Built-in computational blocks
 - **Network/**: Serialization and storage
@@ -58,11 +59,12 @@ CompX is a **visual computational graph system** that enables users to build, ex
 **Dependencies**: Minimal (lodash, uuid, loglevel)
 
 **Exports**:
+
 ```typescript
-export { Graph } from './Graph/Graph'
-export { Block } from './Graph/Block'
-export { Edge } from './Graph/Edge'
-export { Port } from './Graph/Port'
+export { Graph } from './Graph/Graph';
+export { Block } from './Graph/Block';
+export { Edge } from './Graph/Edge';
+export { Port } from './Graph/Port';
 // ... default blocks, types, helpers
 ```
 
@@ -71,12 +73,14 @@ export { Port } from './Graph/Port'
 **Purpose**: Web-based visual interface for graph construction and execution
 
 **Key Modules**:
+
 - **app/Container/Canvas/**: Visual graph rendering (React-Konva)
 - **app/Container/Overlay/**: UI controls and toolbars
 - **store/**: Redux state management
 - **theme/**: Dark/light theme definitions
 
 **Dependencies**:
+
 - React 18.2, Redux Toolkit
 - React-Konva (canvas visualization)
 - Bootstrap 5.2 (UI components)
@@ -89,6 +93,7 @@ export { Port } from './Graph/Port'
 **Purpose**: Electron main process for desktop distribution
 
 **Key Components**:
+
 - Window management
 - Main process lifecycle
 - Bundles web_app as renderer process
@@ -104,6 +109,7 @@ export { Port } from './Graph/Port'
 ## Data Flow Architecture
 
 ### Graph Construction Flow
+
 ```
 User Action (UI)
     ↓
@@ -121,6 +127,7 @@ React Re-render (Konva Canvas)
 ```
 
 ### Graph Execution Flow
+
 ```
 Execute(T, dt)
     ↓
@@ -146,6 +153,7 @@ For each time step (t):
 **File**: `packages/common/src/Graph/Graph.ts:334-381`
 
 **Algorithm**: Input-counting approach
+
 1. Identify all source blocks (no inputs)
 2. Track number of unfulfilled inputs per block
 3. Process sources in DFS order
@@ -162,6 +170,7 @@ For each time step (t):
 **File**: `packages/common/src/Graph/Graph.ts:261-318`
 
 **Algorithm**: Kosaraju's Algorithm
+
 1. DFS on graph, track finish times
 2. Transpose graph (reverse all edges)
 3. DFS on transposed graph in decreasing finish time order
@@ -178,6 +187,7 @@ For each time step (t):
 **File**: `packages/common/src/Graph/Graph.ts:170-235`
 
 **Algorithm**: DFS-based classification
+
 - **Tree Edge**: Parent-child in DFS tree
 - **Back Edge**: Descendent to ancestor (feedback loop)
 - **Forward Edge**: Ancestor to descendent (non-tree)
@@ -192,6 +202,7 @@ For each time step (t):
 **File**: `packages/common/src/Graph/Graph.ts:238-258`
 
 **Algorithm**:
+
 1. Deep clone graph storage
 2. Swap input/output ports for all blocks
 3. Swap input/output for all edges
@@ -209,12 +220,12 @@ For each time step (t):
 
 ```typescript
 type PortTypes = {
-  'number': number
-  'vector': Vector2D
-  'matrix': Matrix2D
-  'boolean': boolean
-  'string': string
-}
+  number: number;
+  vector: Vector2D;
+  matrix: Matrix2D;
+  boolean: boolean;
+  string: string;
+};
 ```
 
 **Type Safety**: Compile-time validation of port connections via TypeScript generics
@@ -231,6 +242,7 @@ class Block<
 ```
 
 **Mapped Types** convert string tuples to actual types:
+
 ```typescript
 MapStringsToTypes<['number', 'vector']>
   → [number, Vector2D]
@@ -241,6 +253,7 @@ MapStringsToTypes<['number', 'vector']>
 ## State Management (Redux)
 
 ### Store Structure
+
 ```typescript
 {
   graph: {
@@ -260,9 +273,11 @@ MapStringsToTypes<['number', 'vector']>
 ### Action Patterns
 
 **Graph Actions** (`packages/web_app/src/store/actions/graphactions.ts`):
+
 - Dispatch action → Reducer → Graph method call → State update
 
 **Canvas Actions** (`packages/web_app/src/store/actions/canvasactions.ts`):
+
 - Pure state updates (no Graph interaction)
 
 ## Block Execution Model
@@ -272,15 +287,17 @@ MapStringsToTypes<['number', 'vector']>
 Blocks execute via **callback functions** defined in domain-specific syntax:
 
 **Syntax Transformations**:
+
 ```javascript
 // User writes:
-return [inputPort[in1] * 2]
+return [inputPort[in1] * 2];
 
 // Compiled to:
-return [newInputs[0] * 2]
+return [newInputs[0] * 2];
 ```
 
 **Special Variables**:
+
 - `inputPort[name]` → Current input value
 - `prevInput[name]` → Previous input (creates pseudo-source)
 - `prevOutput[name]` → Previous output (for state)
@@ -293,6 +310,7 @@ return [newInputs[0] * 2]
 **File**: `packages/common/src/Graph/Graph.ts:384-424`
 
 **Time-Stepped Simulation**:
+
 ```typescript
 Execute(T: number | 'infinite', dt: number) {
   let t = 0.0
@@ -313,6 +331,7 @@ Execute(T: number | 'infinite', dt: number) {
 ## Visualization Architecture (React-Konva)
 
 ### Canvas Hierarchy
+
 ```
 <Stage>
   <Layer name="grid">
@@ -328,6 +347,7 @@ Execute(T: number | 'infinite', dt: number) {
 ```
 
 ### Rendering Strategy
+
 - **Canvas-based**: Uses HTML5 Canvas via Konva library
 - **React Integration**: React-Konva bridges React and Konva
 - **Performance**: Efficient for moderate graphs (~100-1000 elements)
@@ -340,16 +360,14 @@ Execute(T: number | 'infinite', dt: number) {
 **File**: `packages/common/src/Helpers/ErrorHandling.ts`
 
 **Error Levels**:
+
 - `'error'`: Critical failures, throw exceptions
 - `'warning'`: Non-critical issues, log and continue
 
 **Pattern**:
+
 ```typescript
-throw new CompXError(
-  'warning',
-  'Add Edge Warning',
-  'Port type mismatch'
-)
+throw new CompXError('warning', 'Add Edge Warning', 'Port type mismatch');
 ```
 
 **Propagation**: Errors bubble up to UI layer for user notification
@@ -361,6 +379,7 @@ throw new CompXError(
 **Tool**: Lerna 6.4.1 with npm workspaces
 
 **Build Order**:
+
 1. `@compx/common` (no dependencies)
 2. `@compx/web_app` (depends on common)
 3. `@compx/electron_loader` (independent)
@@ -371,10 +390,12 @@ throw new CompXError(
 **File**: `packages/web_app/webpack/webpack.config.js`
 
 **Build Targets**:
+
 - **web**: Standalone web application
 - **electron**: Bundled for Electron renderer process
 
 **Key Features**:
+
 - TypeScript compilation via ts-loader
 - Babel for React JSX
 - CSS extraction
@@ -383,12 +404,14 @@ throw new CompXError(
 ## Security Considerations
 
 ### Callback Execution
+
 - Uses `new Function()` constructor for dynamic callbacks
 - **Risk**: Code injection if user input not sanitized
 - **Mitigation**: Syntax transformation validates against defined patterns
 - **Future**: Consider safer alternatives (sandboxed execution, AST parsing)
 
 ### Data Validation
+
 - Port type checking at connection time
 - Graph structure validation before execution
 - Input validation in all public Graph methods
@@ -396,6 +419,7 @@ throw new CompXError(
 ## Performance Characteristics
 
 ### Algorithmic Complexity
+
 - **AddBlock/RemoveBlock**: O(1) with O(E) edge cleanup
 - **AddEdge/RemoveEdge**: O(1)
 - **DFS**: O(V + E)
@@ -404,6 +428,7 @@ throw new CompXError(
 - **Execute**: O(V × steps)
 
 ### Scalability Limits
+
 - **Graph Size**: Algorithms scale to 1000s of blocks
 - **UI Performance**: Canvas rendering degrades >1000 elements
 - **Execution Speed**: Synchronous, limited by JavaScript event loop
@@ -411,18 +436,21 @@ throw new CompXError(
 ## Extension Points
 
 ### Adding New Port Types
+
 1. Update `PortTypes` interface
 2. Add initializer to `PortTypeInitializers`
 3. Update UI for type selection
 4. Consider serialization impact
 
 ### Adding New Default Blocks
+
 1. Create block definition in `DefaultBlocks/`
 2. Define callback string
 3. Register in startup
 4. Add UI icon/representation
 
 ### Custom Algorithms
+
 1. Extend Graph class methods
 2. Maintain O(V+E) complexity where possible
 3. Add tests for new algorithms
@@ -431,11 +459,13 @@ throw new CompXError(
 ## Testing Architecture
 
 ### Test Organization
+
 - Unit tests colocated in `__tests__/` directories
 - Test resources in `__tests__/Resources/`
 - Jest configuration per package
 
 ### Coverage Goals
+
 - Core algorithms: 100% coverage
 - Graph operations: Full edge case coverage
 - UI components: Interaction and rendering tests

--- a/claudedocs/DEVELOPMENT_GUIDE.md
+++ b/claudedocs/DEVELOPMENT_GUIDE.md
@@ -24,6 +24,7 @@ npm test
 ```
 
 ### Project Structure
+
 ```
 CompX/
 ├── packages/
@@ -50,6 +51,7 @@ npm run web:build
 ```
 
 **Development Features**:
+
 - Hot module replacement (HMR)
 - Source maps for debugging
 - TypeScript type checking
@@ -66,6 +68,7 @@ npm run electron:build
 ```
 
 **Build Process**:
+
 1. Build `@compx/electron_loader`
 2. Build `@compx/web_app` with `BUILD_TYPE=electron`
 3. Copy bundles to `@compx/electron_app/dist/renderer/`
@@ -90,11 +93,11 @@ npx lerna exec --scope=@compx/common -- npm run build
 **1. Create Block Definition** (`packages/common/src/DefaultBlocks/NewBlock.ts`):
 
 ```typescript
-import { BlockStorageType } from '../Network/GraphItemStorage/BlockStorage'
+import { BlockStorageType } from '../Network/GraphItemStorage/BlockStorage';
 
 export const NewBlock: BlockStorageType<
-  ['input1', 'input2'],  // Input port types
-  ['output']             // Output port types
+  ['input1', 'input2'], // Input port types
+  ['output'] // Output port types
 > = {
   name: 'NewBlock',
   description: 'Performs custom computation',
@@ -103,29 +106,27 @@ export const NewBlock: BlockStorageType<
     { name: 'input1', type: 'number' },
     { name: 'input2', type: 'number' }
   ],
-  outputPorts: [
-    { name: 'output', type: 'number' }
-  ],
+  outputPorts: [{ name: 'output', type: 'number' }],
   callbackString: `
     const result = inputPort[input1] + inputPort[input2];
     return [result];
   `
-}
+};
 ```
 
 **2. Export Block** (`packages/common/src/DefaultBlocks/index.ts`):
 
 ```typescript
-export { NewBlock } from './NewBlock'
+export { NewBlock } from './NewBlock';
 ```
 
 **3. Register in Electron App** (`packages/electron_app/src/startup/defaultblockcreation.ts`):
 
 ```typescript
-import { NewBlock } from '@compx/common'
+import { NewBlock } from '@compx/common';
 
 // In initialization function
-blocks.push(NewBlock)
+blocks.push(NewBlock);
 ```
 
 **4. Add UI Component** (Optional, `packages/web_app/src/app/Container/Canvas/Graph/VisualTypes/`):
@@ -133,32 +134,28 @@ blocks.push(NewBlock)
 ```tsx
 // Custom visualization for block
 export const NewBlockComponent: React.FC<BlockComponentProps> = ({ block }) => {
-  return (
-    <Group>
-      {/* Custom Konva shapes */}
-    </Group>
-  )
-}
+  return <Group>{/* Custom Konva shapes */}</Group>;
+};
 ```
 
 **5. Test Block**:
 
 ```typescript
 // packages/common/__tests__/NewBlock.test.ts
-import { Graph } from '../src/Graph/Graph'
-import { NewBlock } from '../src/DefaultBlocks/NewBlock'
+import { Graph } from '../src/Graph/Graph';
+import { NewBlock } from '../src/DefaultBlocks/NewBlock';
 
 describe('NewBlock', () => {
   it('should add inputs correctly', () => {
-    const graph = new Graph({ blocks: [], edges: [] })
-    const blockId = graph.AddBlock(NewBlock)
+    const graph = new Graph({ blocks: [], edges: [] });
+    const blockId = graph.AddBlock(NewBlock);
 
-    const block = graph.blocks.find(b => b.id === blockId)
-    block?.Execute(0, 0.01, [5, 10])
+    const block = graph.blocks.find((b) => b.id === blockId);
+    block?.Execute(0, 0.01, [5, 10]);
 
-    expect(block?.outputPorts[0].GetObjectValue()).toBe(15)
-  })
-})
+    expect(block?.outputPorts[0].GetObjectValue()).toBe(15);
+  });
+});
 ```
 
 ### Adding a New Port Type
@@ -167,29 +164,29 @@ describe('NewBlock', () => {
 
 ```typescript
 // Add custom type (e.g., Complex number)
-import { Complex } from '../Types/Complex'
+import { Complex } from '../Types/Complex';
 
 type PortTypes = {
-  'number': number
-  'vector': Vector2D
-  'matrix': Matrix2D
-  'boolean': boolean
-  'string': string
-  'complex': Complex  // New type
-}
+  number: number;
+  vector: Vector2D;
+  matrix: Matrix2D;
+  boolean: boolean;
+  string: string;
+  complex: Complex; // New type
+};
 ```
 
 **2. Add Type Initializer**:
 
 ```typescript
 const PortTypeInitializers = {
-  'number': 0,
-  'vector': new Vector2D(0, 0),
-  'matrix': new Matrix2D(0, 0),
-  'boolean': false,
-  'string': '',
-  'complex': new Complex(0, 0)  // New initializer
-}
+  number: 0,
+  vector: new Vector2D(0, 0),
+  matrix: new Matrix2D(0, 0),
+  boolean: false,
+  string: '',
+  complex: new Complex(0, 0) // New initializer
+};
 ```
 
 **3. Update UI** (`packages/web_app/src/app/Container/...`):
@@ -218,9 +215,9 @@ public hasMultipleSources(): boolean {
 ```typescript
 // packages/common/__tests__/Graph.test.ts
 it('should detect multiple sources', () => {
-  const graph = new Graph(testGraphData)
-  expect(graph.hasMultipleSources()).toBe(true)
-})
+  const graph = new Graph(testGraphData);
+  expect(graph.hasMultipleSources()).toBe(true);
+});
 ```
 
 **4. Update Compile Order** (if execution affected):
@@ -254,42 +251,42 @@ npm test -- --coverage
 **Unit Test Example** (`packages/common/__tests__/Graph.test.ts`):
 
 ```typescript
-import { Graph } from '../src/Graph/Graph'
-import { Constant } from '../src/DefaultBlocks/Constant'
+import { Graph } from '../src/Graph/Graph';
+import { Constant } from '../src/DefaultBlocks/Constant';
 
 describe('Graph', () => {
-  let graph: Graph
+  let graph: Graph;
 
   beforeEach(() => {
-    graph = new Graph({ blocks: [], edges: [] })
-  })
+    graph = new Graph({ blocks: [], edges: [] });
+  });
 
   it('should add blocks successfully', () => {
-    const blockId = graph.AddBlock(Constant)
-    expect(graph.blocks).toHaveLength(1)
-    expect(graph.blocks[0].id).toBe(blockId)
-  })
+    const blockId = graph.AddBlock(Constant);
+    expect(graph.blocks).toHaveLength(1);
+    expect(graph.blocks[0].id).toBe(blockId);
+  });
 
   it('should throw error when removing non-existent block', () => {
-    expect(() => graph.RemoveBlock('invalid-id')).toThrow()
-  })
-})
+    expect(() => graph.RemoveBlock('invalid-id')).toThrow();
+  });
+});
 ```
 
 **Integration Test Example**:
 
 ```typescript
 it('should execute simple graph correctly', () => {
-  const constantId = graph.AddBlock(Constant)
-  const gainId = graph.AddBlock(Gain)
+  const constantId = graph.AddBlock(Constant);
+  const gainId = graph.AddBlock(Gain);
 
-  graph.AddEdge(constantId, 'value', gainId, 'in')
+  graph.AddEdge(constantId, 'value', gainId, 'in');
 
-  graph.Execute(1.0, 0.1)
+  graph.Execute(1.0, 0.1);
 
-  const gainBlock = graph.blocks.find(b => b.id === gainId)
-  expect(gainBlock?.outputPorts[0].GetObjectValue()).toBe(10) // 5 * 2
-})
+  const gainBlock = graph.blocks.find((b) => b.id === gainId);
+  expect(gainBlock?.outputPorts[0].GetObjectValue()).toBe(10); // 5 * 2
+});
 ```
 
 ### Test Resources
@@ -304,9 +301,10 @@ Test graphs stored in `packages/common/__tests__/Resources/`:
 ```
 
 Load with:
+
 ```typescript
-import testGraph from './Resources/TestGraphSimple1.json'
-const graph = new Graph(testGraph)
+import testGraph from './Resources/TestGraphSimple1.json';
+const graph = new Graph(testGraph);
 ```
 
 ## Code Quality
@@ -344,6 +342,7 @@ cd packages/common && npx tsc --noEmit
 ### Pre-Commit Hooks
 
 **Husky** runs checks before commits:
+
 1. Prettier formatting on staged files
 2. ESLint on TypeScript files
 3. Type checking (optional)
@@ -355,16 +354,19 @@ Configured in `.husky/pre-commit`
 ### Web Application Debugging
 
 **Browser DevTools**:
+
 1. Open Chrome DevTools (F12)
 2. Go to Sources tab
 3. Set breakpoints in TypeScript source (via source maps)
 
 **Redux DevTools**:
+
 1. Install Redux DevTools Extension
 2. Open extension panel
 3. Inspect state changes and actions
 
 **React DevTools**:
+
 1. Install React DevTools Extension
 2. Inspect component tree
 3. View props/state
@@ -372,46 +374,52 @@ Configured in `.husky/pre-commit`
 ### Electron Application Debugging
 
 **Main Process**:
+
 ```bash
 # Launch with Node.js debugger
 node --inspect-brk packages/electron_app/dist/index.js
 ```
 
 **Renderer Process**:
+
 - Use Chrome DevTools (same as web app)
 - Access via `View > Toggle Developer Tools` in Electron
 
 ### Graph Execution Debugging
 
 **Log Block Execution**:
+
 ```typescript
 // In Execute() method
 blockCompOrder.forEach((bId) => {
-  const block = this.blocks.find((b) => b.id === bId)!
+  const block = this.blocks.find((b) => b.id === bId)!;
   console.log(`Executing ${block.name}`, {
-    inputs: block.inputPorts.map(p => p.GetObjectValue()),
-    outputs: block.outputPorts.map(p => p.GetObjectValue())
-  })
+    inputs: block.inputPorts.map((p) => p.GetObjectValue()),
+    outputs: block.outputPorts.map((p) => p.GetObjectValue())
+  });
   // ... rest of execution
-})
+});
 ```
 
 **Visualize Compile Order**:
+
 ```typescript
-const compileOrder = graph.GetBlockCompileOrder()
-console.log('Execution order:', compileOrder.map(id =>
-  graph.blocks.find(b => b.id === id)?.name
-))
+const compileOrder = graph.GetBlockCompileOrder();
+console.log(
+  'Execution order:',
+  compileOrder.map((id) => graph.blocks.find((b) => b.id === id)?.name)
+);
 ```
 
 **Check Graph Validity**:
+
 ```typescript
 if (!graph.isValidGraph()) {
-  const scc = graph.SCC()
-  const sources = graph.GetSourceBlocks()
-  console.log('Invalid graph detected')
-  console.log('Components:', scc)
-  console.log('Sources:', sources)
+  const scc = graph.SCC();
+  const sources = graph.GetSourceBlocks();
+  console.log('Invalid graph detected');
+  console.log('Components:', scc);
+  console.log('Sources:', sources);
 }
 ```
 
@@ -438,10 +446,12 @@ npm run electron:build
 ### Deployment
 
 **Web Application**:
+
 - Deploy `packages/web_app/dist/` to static hosting (Netlify, Vercel, S3)
 - Configure routes for SPA
 
 **Electron Application**:
+
 - Package with `electron-builder` or similar
 - Create installers for Windows/Mac/Linux
 
@@ -450,24 +460,29 @@ npm run electron:build
 ### Graph Execution Performance
 
 **Reduce Callback Overhead**:
+
 - Minimize string transformations in `ConvertCallback()`
 - Cache compiled callbacks
 
 **Optimize Compile Order**:
+
 - Reduce DFS calls by caching adjacency lists
 
 **Batch Updates**:
+
 - Group multiple block additions
 - Recalculate compile order only when needed
 
 ### UI Performance
 
 **Canvas Rendering**:
+
 - Limit blocks to ~1000 for smooth performance
 - Use Konva layers for efficient updates
 - Implement viewport culling for large graphs
 
 **Redux Optimizations**:
+
 - Use `useSelector` with equality checks
 - Memoize selectors with `reselect`
 - Avoid unnecessary re-renders
@@ -479,6 +494,7 @@ npm run electron:build
 **Cause**: Dependency version conflicts
 
 **Solution**:
+
 ```bash
 npm run clean
 rm -rf node_modules package-lock.json
@@ -497,17 +513,18 @@ npm run bootstrap
 **Cause**: Invalid compile order or missing callbacks
 
 **Solution**:
+
 ```typescript
 // Debug compile order
-const order = graph.GetBlockCompileOrder()
-console.log('Compile order:', order)
+const order = graph.GetBlockCompileOrder();
+console.log('Compile order:', order);
 
 // Verify blocks have callbacks
-graph.blocks.forEach(block => {
+graph.blocks.forEach((block) => {
   if (!block.callbackString) {
-    console.warn(`Block ${block.name} missing callback`)
+    console.warn(`Block ${block.name} missing callback`);
   }
-})
+});
 ```
 
 ### Issue: Port Type Mismatch Error
@@ -515,39 +532,45 @@ graph.blocks.forEach(block => {
 **Cause**: Attempting to connect incompatible port types
 
 **Solution**: Verify port types match before connection:
+
 ```typescript
-const outputPort = graph.blocks[0].outputPorts[0]
-const inputPort = graph.blocks[1].inputPorts[0]
+const outputPort = graph.blocks[0].outputPorts[0];
+const inputPort = graph.blocks[1].inputPorts[0];
 
 if (outputPort.type !== inputPort.type) {
-  console.error('Type mismatch:', outputPort.type, '!==', inputPort.type)
+  console.error('Type mismatch:', outputPort.type, '!==', inputPort.type);
 }
 ```
 
 ## Best Practices
 
 ### Code Organization
+
 - Keep block logic in `packages/common/src/DefaultBlocks/`
 - UI components in `packages/web_app/src/app/Container/`
 - Tests colocated with source in `__tests__/`
 
 ### Naming Conventions
+
 - **Classes**: PascalCase (Graph, Block, Edge)
 - **Functions**: camelCase (AddBlock, GetSourceBlocks)
 - **Constants**: UPPER_SNAKE_CASE
 - **Files**: PascalCase for components, camelCase for utilities
 
 ### Error Handling
+
 - Use `CompXError` for domain errors
 - Validate inputs before operations
 - Provide clear error messages with context
 
 ### Documentation
+
 - JSDoc for public APIs
 - Inline comments for complex algorithms
 - Update README when adding features
 
 ### Git Workflow
+
 - Feature branches from `master`
 - Descriptive commit messages
 - Run tests before pushing

--- a/claudedocs/DOCKER.md
+++ b/claudedocs/DOCKER.md
@@ -3,6 +3,7 @@
 Complete guide for building and deploying CompX using Docker.
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Quick Start](#quick-start)
 - [Build Stages](#build-stages)
@@ -16,6 +17,7 @@ Complete guide for building and deploying CompX using Docker.
 ## Overview
 
 CompX provides a multi-stage Dockerfile that supports:
+
 - **Web Server**: Production-ready nginx deployment (recommended for Docker)
 - **Development Server**: Hot-reload development environment
 - **Electron Builder**: Desktop application packaging (Linux)
@@ -86,6 +88,7 @@ The Dockerfile defines multiple build stages for different purposes:
 **Purpose**: Common foundation for all build stages
 
 **Key Features**:
+
 - Node.js 18 Alpine (minimal size)
 - Python 3.12 + setuptools (required for native npm modules)
 - Build tools: `make`, `g++`
@@ -93,6 +96,7 @@ The Dockerfile defines multiple build stages for different purposes:
 - Common package source code ready
 
 **Dependencies Installed**:
+
 - All packages from root `package.json`
 - All workspace packages (`@compx/common`, `@compx/web_app`, etc.)
 - Native modules built successfully (`@parcel/watcher`, etc.)
@@ -104,6 +108,7 @@ The Dockerfile defines multiple build stages for different purposes:
 **Inherits From**: `base`
 
 **Output**:
+
 - Compiled loader assets in `dist/`
 - Used by Electron desktop application
 
@@ -116,6 +121,7 @@ The Dockerfile defines multiple build stages for different purposes:
 **Inherits From**: `base`
 
 **Contains**:
+
 - Web app source code
 - Webpack configuration
 - Babel configuration
@@ -130,6 +136,7 @@ The Dockerfile defines multiple build stages for different purposes:
 **Command**: `npm run start --workspace=@compx/web_app`
 
 **Usage**:
+
 ```bash
 docker build --target web_dev -t compx:dev .
 docker run -p 3000:3000 -v $(pwd)/packages/web_app/src:/compx/packages/web_app/src compx:dev
@@ -144,6 +151,7 @@ docker run -p 3000:3000 -v $(pwd)/packages/web_app/src:/compx/packages/web_app/s
 **Environment**: `BUILD_TYPE=web`
 
 **Output**:
+
 - Minified, bundled JavaScript in `dist/`
 - Production-ready static assets
 - Optimized for performance
@@ -157,12 +165,14 @@ docker run -p 3000:3000 -v $(pwd)/packages/web_app/src:/compx/packages/web_app/s
 **Inherits From**: nginx:latest
 
 **Features**:
+
 - Lightweight (~250MB total)
 - High-performance static file serving
 - Production-ready configuration
 - No Node.js runtime overhead
 
 **Configuration**:
+
 - Serves from `/usr/share/nginx/html/`
 - Default port: 80
 - Copied from `web_builder` stage
@@ -188,11 +198,13 @@ docker build --target web_server -t compx:latest .
 ```
 
 **With custom tags:**
+
 ```bash
 docker build --target web_server -t compx:1.0.0 -t compx:latest .
 ```
 
 **Build arguments:**
+
 ```bash
 docker build \
   --target web_server \
@@ -218,17 +230,20 @@ docker build -t compx:all .
 ### Build Performance
 
 **Cache Optimization:**
+
 ```bash
 # Use BuildKit for better caching
 DOCKER_BUILDKIT=1 docker build --target web_server -t compx:latest .
 ```
 
 **No Cache (Clean Build):**
+
 ```bash
 docker build --no-cache --target web_server -t compx:latest .
 ```
 
 **Expected Build Times:**
+
 - First build: ~3-5 minutes (downloading dependencies)
 - Subsequent builds: ~30-60 seconds (using cache)
 - No-cache build: ~3-5 minutes
@@ -367,6 +382,7 @@ docker run -d \
 **Cause**: Building all stages including electron_builder without targeting web_server
 
 **Solution**:
+
 ```bash
 docker build --target web_server -t compx:latest .
 ```
@@ -376,6 +392,7 @@ docker build --target web_server -t compx:latest .
 **Cause**: Webpack alias not configured or cache issue
 
 **Solution**:
+
 ```bash
 docker build --no-cache --target web_server -t compx:latest .
 ```
@@ -385,6 +402,7 @@ docker build --no-cache --target web_server -t compx:latest .
 **Cause**: Missing Python dependencies in Alpine
 
 **Solution**: Already fixed in Dockerfile with:
+
 ```dockerfile
 RUN apk add --no-cache python3 py3-setuptools make g++
 ```
@@ -394,11 +412,13 @@ RUN apk add --no-cache python3 py3-setuptools make g++
 #### Issue: Container exits immediately
 
 **Check logs:**
+
 ```bash
 docker logs compx
 ```
 
 **Verify build:**
+
 ```bash
 docker run -it compx:latest sh
 ```
@@ -406,12 +426,14 @@ docker run -it compx:latest sh
 #### Issue: Cannot access on localhost
 
 **Check port mapping:**
+
 ```bash
 docker ps
 # Should show: 0.0.0.0:8080->80/tcp
 ```
 
 **Test from container:**
+
 ```bash
 docker exec compx curl http://localhost:80
 ```
@@ -419,11 +441,13 @@ docker exec compx curl http://localhost:80
 #### Issue: 404 errors
 
 **Check static files:**
+
 ```bash
 docker exec compx ls -la /usr/share/nginx/html/
 ```
 
 **Expected files:**
+
 - `index.html`
 - `bundle.js`
 - Other static assets
@@ -433,12 +457,14 @@ docker exec compx ls -la /usr/share/nginx/html/
 #### Slow Build Times
 
 **Use BuildKit:**
+
 ```bash
 export DOCKER_BUILDKIT=1
 docker build --target web_server -t compx:latest .
 ```
 
 **Prune build cache:**
+
 ```bash
 docker builder prune
 ```
@@ -446,12 +472,14 @@ docker builder prune
 #### Large Image Size
 
 **Check image size:**
+
 ```bash
 docker images compx
 # Should be ~250MB for web_server
 ```
 
 **Reduce size further:**
+
 ```bash
 # Use multi-stage build with smaller base
 # Already optimized in current Dockerfile
@@ -459,12 +487,12 @@ docker images compx
 
 ### Common Errors
 
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `ENOENT: no such file` | Missing source files | Check .dockerignore |
-| `npm ERR! workspace` | Workspace misconfiguration | Verify lerna.json |
-| `webpack compiled with errors` | Build failure | Check build logs |
-| `Port already in use` | Port conflict | Use different port or stop conflicting process |
+| Error                          | Cause                      | Solution                                       |
+| ------------------------------ | -------------------------- | ---------------------------------------------- |
+| `ENOENT: no such file`         | Missing source files       | Check .dockerignore                            |
+| `npm ERR! workspace`           | Workspace misconfiguration | Verify lerna.json                              |
+| `webpack compiled with errors` | Build failure              | Check build logs                               |
+| `Port already in use`          | Port conflict              | Use different port or stop conflicting process |
 
 ---
 
@@ -483,18 +511,19 @@ services:
       context: .
       target: web_server
     ports:
-      - "8080:80"
+      - '8080:80'
     environment:
       - NODE_ENV=production
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:80']
       interval: 30s
       timeout: 10s
       retries: 3
 ```
 
 **Usage:**
+
 ```bash
 docker-compose up -d
 docker-compose logs -f
@@ -521,17 +550,17 @@ spec:
         app: compx
     spec:
       containers:
-      - name: compx
-        image: compx:latest
-        ports:
-        - containerPort: 80
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
+        - name: compx
+          image: compx:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '250m'
+            limits:
+              memory: '512Mi'
+              cpu: '500m'
 ---
 apiVersion: v1
 kind: Service
@@ -541,8 +570,8 @@ spec:
   selector:
     app: compx
   ports:
-  - port: 80
-    targetPort: 80
+    - port: 80
+      targetPort: 80
   type: LoadBalancer
 ```
 

--- a/claudedocs/IMPLEMENTATION_BLOCK_SERVICE_INTEGRATION.md
+++ b/claudedocs/IMPLEMENTATION_BLOCK_SERVICE_INTEGRATION.md
@@ -6,12 +6,14 @@
 ## Build Verification
 
 ✅ **All Builds Successful** (2025-10-28 18:29):
+
 - `electron_app` compiled successfully with TypeScript
 - `web_app` built successfully with Webpack
 - `electron_loader` built successfully
 - All dependencies linked correctly
 
 ✅ **Test Data Prepared**:
+
 - 4 JSON block files created in `~/Library/Application Support/CompX/block_storage/`
   - `test_block_constant.json` - Constant source block
   - `test_block_gain.json` - Gain amplifier block
@@ -29,6 +31,7 @@ Successfully implemented the complete Electron BlockManager and IPC handler syst
 **File**: `packages/electron_app/src/services/BlockManager.ts`
 
 **Features Implemented**:
+
 - Singleton pattern for main process block management
 - JSON file reading from `userData/block_storage/`
 - In-memory caching with Map for performance
@@ -38,6 +41,7 @@ Successfully implemented the complete Electron BlockManager and IPC handler syst
 - Comprehensive error handling with custom error codes
 
 **Key Methods**:
+
 ```typescript
 async initialize(): Promise<void>
 async getAvailableBlocks(): Promise<BlockDefinition[]>
@@ -55,6 +59,7 @@ async reload(): Promise<void>
 **File**: `packages/electron_app/src/ipc/blockServiceHandlers.ts`
 
 **IPC Channels Registered**:
+
 - `block-library:get-all` → Get all available blocks
 - `block-library:get` → Get specific block by name
 - `block-library:search` → Search blocks by query
@@ -62,12 +67,14 @@ async reload(): Promise<void>
 - `block-library:uninstall-pack` → Uninstall block pack (future)
 
 **Features**:
+
 - Automatic BlockManager initialization on app startup
 - Comprehensive logging for debugging
 - Error propagation to renderer process
 - Event emission for library changes (prepared for future)
 
 **Handler Function**:
+
 ```typescript
 async setupBlockServiceHandlers(): Promise<void>
 ```
@@ -77,6 +84,7 @@ async setupBlockServiceHandlers(): Promise<void>
 **File**: `packages/electron_app/src/index.ts`
 
 **Changes**:
+
 - Import `setupBlockServiceHandlers`
 - Call handler setup in `app.on('ready')` before window creation
 - Error handling with console logging
@@ -96,30 +104,33 @@ app.on('ready', async () => {
 ### 4. ✅ Redux Store Updates
 
 **Files Modified**:
+
 - `packages/web_app/src/store/types.ts`
 - `packages/web_app/src/store/actions/actiontypes.ts`
 - `packages/web_app/src/store/actions/graphactions.ts`
 - `packages/web_app/src/store/reducers/graphreducers.ts`
 
 **Changes**:
+
 1. **Removed DefaultBlocks Dependency**:
+
    ```typescript
    // ❌ Old: import { Constant, Sum, Multiply } from '@compx/common/DefaultBlocks';
    // ✅ New: No import, start with empty array
 
-   libraryBlocks: [] // Start empty, will be loaded from BlockService
+   libraryBlocks: []; // Start empty, will be loaded from BlockService
    ```
 
 2. **New Action Type**:
+
    ```typescript
    export const LoadLibraryBlocksActionType = `@@graph_reducer/LOAD_LIBRARY_BLOCKS`;
    ```
 
 3. **New Action Creator**:
+
    ```typescript
-   export const LoadLibraryBlocksAction: ActionType = (
-     blocks: BlockStorageType<any, any>[]
-   ): ActionPayloadType => ({
+   export const LoadLibraryBlocksAction: ActionType = (blocks: BlockStorageType<any, any>[]): ActionPayloadType => ({
      type: LoadLibraryBlocksActionType,
      payload: { blocks }
    });
@@ -137,11 +148,13 @@ app.on('ready', async () => {
 ### 5. ✅ React App Integration
 
 **Files Created/Modified**:
+
 - `packages/web_app/src/index.tsx` - Added BlockServiceProvider
 - `packages/web_app/src/app/BlockLibraryLoader.tsx` - New component
 - `packages/web_app/src/app/app.web.tsx` - Integrated loader
 
 **Architecture**:
+
 ```
 index.tsx
   └─ <Provider store={store}>
@@ -152,6 +165,7 @@ index.tsx
 ```
 
 **BlockLibraryLoader Component**:
+
 ```typescript
 export function BlockLibraryLoader(): null {
   const dispatch = useDispatch();
@@ -244,15 +258,19 @@ export function BlockLibraryLoader(): null {
 ## Configuration
 
 ### Environment Variables
+
 None required - BlockManager automatically uses Electron's `app.getPath('userData')`
 
 ### Storage Location by Platform
+
 - **macOS**: `~/Library/Application Support/CompX/block_storage/`
 - **Windows**: `%APPDATA%/CompX/block_storage/`
 - **Linux**: `~/.config/CompX/block_storage/`
 
 ### JSON File Format
+
 Each block is stored as `{blockName}.json`:
+
 ```json
 {
   "schema_version": "1.0.0",
@@ -270,27 +288,32 @@ Each block is stored as `{blockName}.json`:
 ## Testing Verification Steps
 
 ### 1. Electron App Start
+
 - [ ] No errors during BlockManager initialization
 - [ ] Console logs: "Block service initialized successfully"
 - [ ] Console logs: "BlockManager initialized with X blocks"
 
 ### 2. IPC Communication
+
 - [ ] Console logs: "IPC: GET_ALL - Fetching all blocks"
 - [ ] Console logs: "IPC: GET_ALL - Returning X blocks"
 - [ ] No IPC errors in DevTools console
 
 ### 3. React App Loading
+
 - [ ] Console logs: "Loading X blocks into Redux store"
 - [ ] No BlockService errors
 - [ ] Redux store populated: `state.currentGraph.libraryBlocks.length > 0`
 
 ### 4. Block Library UI
+
 - [ ] Block search shows ALL JSON blocks (not just Constant, Sum, Multiply)
 - [ ] Block count matches number of JSON files
 - [ ] Block details display correctly
 - [ ] Block search works properly
 
 ### 5. Redux DevTools
+
 - [ ] Action dispatched: `@@graph_reducer/LOAD_LIBRARY_BLOCKS`
 - [ ] State updated: `currentGraph.libraryBlocks: [...]`
 - [ ] Array contains BlockDefinition objects from JSON files
@@ -304,17 +327,20 @@ Each block is stored as `{blockName}.json`:
 ## Future Enhancements
 
 ### Immediate
+
 - [ ] Connect LibraryChangeEvent broadcasting to all windows
 - [ ] Implement block pack installation (ZIP file extraction)
 - [ ] Add block validation on load (schema validation)
 
 ### Medium-Term
+
 - [ ] Block editor UI for creating/editing blocks
 - [ ] Block pack marketplace integration
 - [ ] Block version management and updates
 - [ ] Block dependencies and compatibility checking
 
 ### Long-Term
+
 - [ ] Cloud block library synchronization
 - [ ] Collaborative block sharing
 - [ ] Block analytics and usage tracking
@@ -323,9 +349,11 @@ Each block is stored as `{blockName}.json`:
 ## DefaultBlocks Cleanup
 
 ### Current Status
+
 **❌ Cannot delete yet** - Need to verify implementation works first
 
 ### Deletion Checklist
+
 - [ ] Start Electron app successfully
 - [ ] Verify JSON blocks load correctly
 - [ ] Verify block search shows all blocks
@@ -336,12 +364,14 @@ Each block is stored as `{blockName}.json`:
   ```
 
 ### Safe Deletion Command
+
 ```bash
 # Only run after verification!
 rm -rf packages/common/src/DefaultBlocks/
 ```
 
 ### Files That Will Be Deleted
+
 - `packages/common/src/DefaultBlocks/Constant.ts`
 - `packages/common/src/DefaultBlocks/Gain.ts`
 - `packages/common/src/DefaultBlocks/Integrator.ts`
@@ -352,12 +382,14 @@ rm -rf packages/common/src/DefaultBlocks/
 ## Debugging
 
 ### Check Block Storage Path
+
 ```typescript
 // In Electron main process console
 console.log(blockManager.getStoragePath());
 ```
 
 ### Check Loaded Blocks
+
 ```typescript
 // In Electron main process console
 console.log(blockManager.getBlockCount());
@@ -365,6 +397,7 @@ console.log(await blockManager.getAvailableBlocks());
 ```
 
 ### Check IPC Communication
+
 ```typescript
 // In Electron renderer DevTools console
 const { ipcRenderer } = require('electron');
@@ -373,14 +406,16 @@ console.log(blocks);
 ```
 
 ### Check Redux State
+
 ```javascript
 // In browser DevTools console (with Redux DevTools)
-window.__REDUX_DEVTOOLS_EXTENSION__.getState().currentGraph.libraryBlocks
+window.__REDUX_DEVTOOLS_EXTENSION__.getState().currentGraph.libraryBlocks;
 ```
 
 ## Success Criteria
 
 ✅ **Implementation Complete** when:
+
 1. Electron app starts without errors
 2. BlockManager loads JSON files from disk
 3. IPC handlers respond correctly
@@ -389,6 +424,7 @@ window.__REDUX_DEVTOOLS_EXTENSION__.getState().currentGraph.libraryBlocks
 6. Block library UI shows all JSON blocks
 
 🚀 **Ready for Production** when:
+
 1. All tests pass
 2. Block search shows >3 blocks
 3. No DefaultBlocks imports remain

--- a/claudedocs/QUICK_START.md
+++ b/claudedocs/QUICK_START.md
@@ -32,21 +32,26 @@ npm run web:start
 ### Build a Simple Gain Graph
 
 **1. Add Constant Block**
+
 - Drag "Constant" from library
 - Set value to `5`
 
 **2. Add Gain Block**
+
 - Drag "Gain" from library
 - Set gain to `2`
 
 **3. Add Scope Block**
+
 - Drag "Scope" from library
 
 **4. Connect Blocks**
+
 - Connect Constant output → Gain input
 - Connect Gain output → Scope input
 
 **5. Execute**
+
 - Click "Run" button
 - Scope shows `10` (5 × 2)
 
@@ -55,23 +60,23 @@ npm run web:start
 ### Core Graph Operations
 
 ```typescript
-import { Graph } from '@compx/common'
-import { Constant, Gain, Scope } from '@compx/common'
+import { Graph } from '@compx/common';
+import { Constant, Gain, Scope } from '@compx/common';
 
 // Create empty graph
-const graph = new Graph({ blocks: [], edges: [] })
+const graph = new Graph({ blocks: [], edges: [] });
 
 // Add blocks
-const constantId = graph.AddBlock(Constant)
-const gainId = graph.AddBlock(Gain)
-const scopeId = graph.AddBlock(Scope)
+const constantId = graph.AddBlock(Constant);
+const gainId = graph.AddBlock(Gain);
+const scopeId = graph.AddBlock(Scope);
 
 // Connect blocks
-graph.AddEdge(constantId, 'value', gainId, 'in')
-graph.AddEdge(gainId, 'out', scopeId, 'in')
+graph.AddEdge(constantId, 'value', gainId, 'in');
+graph.AddEdge(gainId, 'out', scopeId, 'in');
 
 // Execute simulation
-graph.Execute(10.0, 0.01)  // 10 seconds, 0.01s time step
+graph.Execute(10.0, 0.01); // 10 seconds, 0.01s time step
 ```
 
 ## Creating Your First Custom Block
@@ -80,11 +85,11 @@ graph.Execute(10.0, 0.01)  // 10 seconds, 0.01s time step
 
 ```typescript
 // packages/common/src/DefaultBlocks/Multiplier.ts
-import { BlockStorageType } from '../Network/GraphItemStorage/BlockStorage'
+import { BlockStorageType } from '../Network/GraphItemStorage/BlockStorage';
 
 export const Multiplier: BlockStorageType<
-  ['in1', 'in2'],  // Two number inputs
-  ['out']          // One number output
+  ['in1', 'in2'], // Two number inputs
+  ['out'] // One number output
 > = {
   name: 'Multiplier',
   description: 'Multiplies two inputs',
@@ -93,30 +98,29 @@ export const Multiplier: BlockStorageType<
     { name: 'in1', type: 'number' },
     { name: 'in2', type: 'number' }
   ],
-  outputPorts: [
-    { name: 'out', type: 'number' }
-  ],
+  outputPorts: [{ name: 'out', type: 'number' }],
   callbackString: `
     return [inputPort[in1] * inputPort[in2]];
   `
-}
+};
 ```
 
 ### Export and Use
 
 ```typescript
 // packages/common/src/DefaultBlocks/index.ts
-export { Multiplier } from './Multiplier'
+export { Multiplier } from './Multiplier';
 
 // In your code
-import { Multiplier } from '@compx/common'
+import { Multiplier } from '@compx/common';
 
-const multiplierId = graph.AddBlock(Multiplier)
+const multiplierId = graph.AddBlock(Multiplier);
 ```
 
 ## Common Development Tasks
 
 ### Add a Block
+
 ```typescript
 const blockId = graph.AddBlock({
   name: 'MyBlock',
@@ -125,37 +129,38 @@ const blockId = graph.AddBlock({
   inputPorts: [{ name: 'in', type: 'number' }],
   outputPorts: [{ name: 'out', type: 'number' }],
   callbackString: 'return [inputPort[in] * 2]'
-})
+});
 ```
 
 ### Connect Blocks
+
 ```typescript
-const edgeId = graph.AddEdge(
-  sourceBlockId, 'outputPortName',
-  targetBlockId, 'inputPortName'
-)
+const edgeId = graph.AddEdge(sourceBlockId, 'outputPortName', targetBlockId, 'inputPortName');
 ```
 
 ### Remove Block
+
 ```typescript
-graph.RemoveBlock(blockId)
+graph.RemoveBlock(blockId);
 ```
 
 ### Get Graph Information
+
 ```typescript
-const sources = graph.GetSourceBlocks()
-const sinks = graph.GetSinkBlocks()
-const compileOrder = graph.GetBlockCompileOrder()
-const isValid = graph.isValidGraph()
+const sources = graph.GetSourceBlocks();
+const sinks = graph.GetSinkBlocks();
+const compileOrder = graph.GetBlockCompileOrder();
+const isValid = graph.isValidGraph();
 ```
 
 ### Execute Graph
+
 ```typescript
 // Fixed duration
-graph.Execute(10.0, 0.01)
+graph.Execute(10.0, 0.01);
 
 // Continuous (manual stop)
-graph.Execute('infinite', 0.01)
+graph.Execute('infinite', 0.01);
 ```
 
 ## Project Structure Overview
@@ -181,23 +186,27 @@ CompX/
 ## Development Workflow
 
 ### 1. Make Changes
+
 ```bash
 # Edit files in packages/
 vim packages/common/src/Graph/Graph.ts
 ```
 
 ### 2. Test Changes
+
 ```bash
 npm test -- packages/common
 ```
 
 ### 3. Run Development Server
+
 ```bash
 npm run web:start
 # Changes auto-reload
 ```
 
 ### 4. Build for Production
+
 ```bash
 npm run web:build
 # or
@@ -207,18 +216,21 @@ npm run electron:build
 ## Available Commands
 
 ### Development
+
 ```bash
 npm run web:start           # Start web dev server
 npm run electron:start      # Build and launch Electron
 ```
 
 ### Building
+
 ```bash
 npm run web:build          # Build web app
 npm run electron:build     # Build Electron app
 ```
 
 ### Testing
+
 ```bash
 npm test                   # Run all tests
 npm test -- --watch        # Watch mode
@@ -226,12 +238,14 @@ npm test -- packages/common # Specific package
 ```
 
 ### Code Quality
+
 ```bash
 npm run lint               # ESLint check
 npm run format             # Prettier format
 ```
 
 ### Package Management
+
 ```bash
 npm run clean              # Clean all packages
 npm run bootstrap          # Install dependencies
@@ -242,32 +256,36 @@ npm run bootstrap          # Install dependencies
 ### Graph Not Executing?
 
 **Check compile order**:
+
 ```typescript
-const order = graph.GetBlockCompileOrder()
-console.log(order)
+const order = graph.GetBlockCompileOrder();
+console.log(order);
 ```
 
 **Verify graph validity**:
+
 ```typescript
 if (!graph.isValidGraph()) {
-  console.log('Invalid graph!')
-  console.log('Sources:', graph.GetSourceBlocks())
-  console.log('SCCs:', graph.SCC())
+  console.log('Invalid graph!');
+  console.log('Sources:', graph.GetSourceBlocks());
+  console.log('SCCs:', graph.SCC());
 }
 ```
 
 ### Port Connection Failing?
 
 **Check port types**:
+
 ```typescript
-const outPort = block1.outputPorts[0]
-const inPort = block2.inputPorts[0]
-console.log('Types:', outPort.type, inPort.type)
+const outPort = block1.outputPorts[0];
+const inPort = block2.inputPorts[0];
+console.log('Types:', outPort.type, inPort.type);
 ```
 
 ### Build Errors?
 
 **Clean and rebuild**:
+
 ```bash
 npm run clean
 npm install
@@ -277,17 +295,20 @@ npm run bootstrap
 ## Next Steps
 
 ### Learn More
+
 1. **[ARCHITECTURE.md](./ARCHITECTURE.md)** - System architecture
 2. **[API_REFERENCE.md](./API_REFERENCE.md)** - Complete API documentation
 3. **[DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md)** - Advanced development
 
 ### Try Examples
+
 - Build a feedback loop with Integrator
 - Create multi-input Sum block
 - Implement custom visualization
 - Add new port type (e.g., Complex numbers)
 
 ### Contribute
+
 - Read [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md#best-practices)
 - Follow code quality standards
 - Write tests for new features
@@ -296,59 +317,71 @@ npm run bootstrap
 ## Getting Help
 
 ### Documentation
+
 - **Quick questions**: [CLAUDE.md](../.claude/CLAUDE.md)
 - **API usage**: [API_REFERENCE.md](./API_REFERENCE.md)
 - **Architecture**: [ARCHITECTURE.md](./ARCHITECTURE.md)
 - **Development**: [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md)
 
 ### Community
+
 - GitHub Issues: [Report bugs or request features](https://github.com/your-org/CompX/issues)
 - Discussions: [Ask questions](https://github.com/your-org/CompX/discussions)
 
 ## Common Pitfalls
 
 ### ❌ Port Type Mismatch
+
 ```typescript
 // Wrong: Connecting number to vector
-graph.AddEdge(numberBlock, 'out', vectorBlock, 'in')
+graph.AddEdge(numberBlock, 'out', vectorBlock, 'in');
 ```
+
 ✅ **Solution**: Ensure port types match
 
 ### ❌ Missing Callback
+
 ```typescript
 // Wrong: Block without callback
 const block: BlockStorageType = {
   name: 'MyBlock',
   // ... ports ...
-  callbackString: ''  // Empty!
-}
+  callbackString: '' // Empty!
+};
 ```
+
 ✅ **Solution**: Always provide callback logic
 
 ### ❌ Invalid Graph Structure
+
 ```typescript
 // Wrong: Loop without pseudo-source
-graph.AddEdge(block1, 'out', block2, 'in')
-graph.AddEdge(block2, 'out', block1, 'in')
+graph.AddEdge(block1, 'out', block2, 'in');
+graph.AddEdge(block2, 'out', block1, 'in');
 ```
+
 ✅ **Solution**: Use blocks with `prevInput[]` or `prevOutput[]` in loops
 
 ### ❌ Multiple Edges to Input
+
 ```typescript
 // Wrong: Two edges to same input
-graph.AddEdge(block1, 'out', block3, 'in')
-graph.AddEdge(block2, 'out', block3, 'in')  // Error!
+graph.AddEdge(block1, 'out', block3, 'in');
+graph.AddEdge(block2, 'out', block3, 'in'); // Error!
 ```
+
 ✅ **Solution**: Use Sum block for multiple inputs
 
 ## Performance Tips
 
 ### Graph Execution
+
 - ⚡ Keep graphs under 1000 blocks for optimal UI performance
 - ⚡ Cache compile order if graph structure doesn't change
 - ⚡ Use simple callbacks (avoid complex calculations)
 
 ### UI Rendering
+
 - ⚡ Limit visible blocks when zoomed out
 - ⚡ Use viewport culling for large graphs
 - ⚡ Debounce frequent updates

--- a/claudedocs/README.md
+++ b/claudedocs/README.md
@@ -7,7 +7,9 @@ This directory contains comprehensive documentation for the CompX visual computa
 ## Documentation Structure
 
 ### 📘 [CLAUDE.md](../.claude/CLAUDE.md)
+
 **Project-specific instructions for Claude Code**
+
 - Project overview and capabilities
 - Architecture summary
 - Technology stack
@@ -19,7 +21,9 @@ This directory contains comprehensive documentation for the CompX visual computa
 **When to Use**: Starting point for understanding the project, working with Claude Code
 
 ### 🏗️ [ARCHITECTURE.md](./ARCHITECTURE.md)
+
 **System architecture and design patterns**
+
 - High-level architecture diagrams
 - Package structure and dependencies
 - Core algorithms (DFS, SCC, topological sort)
@@ -33,7 +37,9 @@ This directory contains comprehensive documentation for the CompX visual computa
 **When to Use**: Understanding system design, implementing new features, architectural decisions
 
 ### 📚 [API_REFERENCE.md](./API_REFERENCE.md)
+
 **Complete API documentation**
+
 - Graph class methods
 - Block class API
 - Port and Edge types
@@ -45,7 +51,9 @@ This directory contains comprehensive documentation for the CompX visual computa
 **When to Use**: Implementing features, integrating with graph engine, API usage
 
 ### 🛠️ [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md)
+
 **Practical development workflows**
+
 - Setup and prerequisites
 - Development workflows (web, Electron, packages)
 - Adding features (blocks, port types, algorithms)
@@ -62,6 +70,7 @@ This directory contains comprehensive documentation for the CompX visual computa
 ## Quick Navigation
 
 ### Getting Started
+
 1. Read [CLAUDE.md](../.claude/CLAUDE.md) → Project Overview
 2. Follow [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md#getting-started) → Setup
 3. Review [ARCHITECTURE.md](./ARCHITECTURE.md) → System Understanding
@@ -69,18 +78,22 @@ This directory contains comprehensive documentation for the CompX visual computa
 ### Common Tasks
 
 #### Adding a New Block Type
+
 1. [DEVELOPMENT_GUIDE.md → Adding Features → Adding a New Block Type](./DEVELOPMENT_GUIDE.md#adding-a-new-block-type)
 2. [API_REFERENCE.md → Default Blocks](./API_REFERENCE.md#default-blocks-api)
 
 #### Understanding Graph Algorithms
+
 1. [ARCHITECTURE.md → Core Algorithms](./ARCHITECTURE.md#core-algorithms)
 2. [API_REFERENCE.md → Graph Algorithm Methods](./API_REFERENCE.md#graph-algorithm-methods)
 
 #### Debugging Graph Execution
+
 1. [DEVELOPMENT_GUIDE.md → Debugging → Graph Execution Debugging](./DEVELOPMENT_GUIDE.md#graph-execution-debugging)
 2. [CLAUDE.md → Debugging Tips](../.claude/CLAUDE.md#debugging-tips)
 
 #### API Integration
+
 1. [API_REFERENCE.md → Graph Class](./API_REFERENCE.md#graph-class)
 2. [ARCHITECTURE.md → Data Flow Architecture](./ARCHITECTURE.md#data-flow-architecture)
 
@@ -119,18 +132,21 @@ CompX Documentation
 ## Key Concepts Reference
 
 ### Graph Theory Foundations
+
 - **[Graph](./API_REFERENCE.md#graph-class)**: Container for computational blocks and edges
 - **[Block](./API_REFERENCE.md#block-class)**: Computational node with typed I/O ports
 - **[Edge](./API_REFERENCE.md#edge-class)**: Typed connection between ports
 - **[Port](./API_REFERENCE.md#port-class)**: Typed data endpoint
 
 ### Core Algorithms
+
 - **[DFS (Depth-First Search)](./ARCHITECTURE.md#1-topological-sort-compile-order)**: Graph traversal
 - **[SCC (Strongly Connected Components)](./ARCHITECTURE.md#2-strongly-connected-components-scc)**: Feedback loop detection
 - **[Topological Sort](./ARCHITECTURE.md#1-topological-sort-compile-order)**: Execution order computation
 - **[Edge Classification](./ARCHITECTURE.md#3-edge-classification)**: Structural analysis
 
 ### Package Architecture
+
 - **[@compx/common](./ARCHITECTURE.md#1-compxcommon-core-engine)**: Core graph engine
 - **[@compx/web_app](./ARCHITECTURE.md#2-compxweb_app-react-frontend)**: React UI
 - **[@compx/electron_app](./ARCHITECTURE.md#3-compxelectron_app-desktop-application)**: Desktop wrapper
@@ -139,6 +155,7 @@ CompX Documentation
 ## File Location Guide
 
 ### Source Code
+
 - **Graph Engine**: `packages/common/src/Graph/`
 - **Default Blocks**: `packages/common/src/DefaultBlocks/`
 - **UI Components**: `packages/web_app/src/app/Container/`
@@ -146,10 +163,12 @@ CompX Documentation
 - **Electron Main**: `packages/electron_app/src/`
 
 ### Tests
+
 - **Common Tests**: `packages/common/__tests__/`
 - **Test Resources**: `packages/common/__tests__/Resources/`
 
 ### Configuration
+
 - **Root Config**: `package.json`, `lerna.json`, `tsconfig.json`
 - **Package Configs**: `packages/*/package.json`, `packages/*/tsconfig.json`
 - **Build Config**: `packages/web_app/webpack/`
@@ -157,18 +176,21 @@ CompX Documentation
 ## Development Workflows
 
 ### Web Development
+
 ```bash
 npm run web:start    # Dev server → http://localhost:3000
 npm run web:build    # Production build
 ```
 
 ### Electron Development
+
 ```bash
 npm run electron:start    # Build and launch
 npm run electron:build    # Production build
 ```
 
 ### Testing
+
 ```bash
 npm test                     # All tests
 npm test -- --watch         # Watch mode
@@ -176,6 +198,7 @@ npm test -- packages/common # Specific package
 ```
 
 ### Code Quality
+
 ```bash
 npm run lint           # ESLint
 npm run format         # Prettier
@@ -185,18 +208,21 @@ npx tsc --noEmit       # Type check
 ## Technology Stack Summary
 
 ### Core
+
 - **TypeScript 4.4.4**: Static typing
 - **Lodash**: Utilities
 - **uuid**: ID generation
 - **loglevel**: Logging
 
 ### Frontend
+
 - **React 18.2**: UI framework
 - **Redux Toolkit**: State management
 - **React-Konva**: Canvas visualization
 - **Bootstrap 5.2**: UI components
 
 ### Build & Quality
+
 - **Lerna 6.4.1**: Monorepo management
 - **Webpack 5**: Bundling
 - **Jest 29**: Testing
@@ -205,11 +231,13 @@ npx tsc --noEmit       # Type check
 ## Contributing
 
 ### Before Starting
+
 1. Read [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md)
 2. Set up development environment
 3. Run tests to verify setup
 
 ### Development Process
+
 1. Create feature branch
 2. Implement changes
 3. Write/update tests
@@ -218,6 +246,7 @@ npx tsc --noEmit       # Type check
 6. Create pull request
 
 ### Code Quality Standards
+
 - ESLint: Airbnb config + TypeScript
 - Prettier: Consistent formatting
 - Tests: Maintain coverage
@@ -226,6 +255,7 @@ npx tsc --noEmit       # Type check
 ## Additional Resources
 
 ### External Documentation
+
 - [Lerna Documentation](https://lerna.js.org/)
 - [React Documentation](https://react.dev/)
 - [Redux Toolkit](https://redux-toolkit.js.org/)
@@ -233,12 +263,14 @@ npx tsc --noEmit       # Type check
 - [TypeScript](https://www.typescriptlang.org/)
 
 ### Project Repository
+
 - Main repository: [CompX GitHub](https://github.com/your-org/CompX)
 - Issue tracking: [GitHub Issues](https://github.com/your-org/CompX/issues)
 
 ## Documentation Updates
 
 ### When to Update Documentation
+
 - Adding new features
 - Changing APIs
 - Modifying architecture
@@ -246,6 +278,7 @@ npx tsc --noEmit       # Type check
 - Improving development workflows
 
 ### How to Update
+
 1. Edit relevant markdown files in `claudedocs/`
 2. Update cross-references if structure changes
 3. Maintain consistent formatting
@@ -260,6 +293,7 @@ npx tsc --noEmit       # Type check
 ## Quick Reference Card
 
 ### Essential Commands
+
 ```bash
 npm run bootstrap        # Setup
 npm run web:start       # Dev server
@@ -268,6 +302,7 @@ npm run lint            # Code quality
 ```
 
 ### Key Files
+
 ```
 .claude/CLAUDE.md       # Project instructions
 claudedocs/*.md         # Documentation
@@ -276,6 +311,7 @@ packages/web_app/src/   # UI code
 ```
 
 ### Critical Classes
+
 ```typescript
 Graph                   # Container & algorithms
 Block                   # Computational node
@@ -284,6 +320,7 @@ Port                    # Typed I/O
 ```
 
 ### Common Operations
+
 ```typescript
 graph.AddBlock(...)         // Add block
 graph.AddEdge(...)          // Connect blocks

--- a/claudedocs/TESTING_GUIDE.md
+++ b/claudedocs/TESTING_GUIDE.md
@@ -6,6 +6,7 @@
 ## Quick Start
 
 ### 1. Start Electron App
+
 ```bash
 cd /Users/aidanpetti/Documents/Code/CompX
 npm run electron:start
@@ -14,6 +15,7 @@ npm run electron:start
 ### 2. Expected Console Output
 
 **Main Process Console** (Terminal where you ran `npm run electron:start`):
+
 ```
 Setting up block service IPC handlers...
 Created block storage directory: /Users/aidanpetti/Library/Application Support/CompX/block_storage
@@ -28,6 +30,7 @@ Block service initialized successfully
 ```
 
 **Renderer Process Console** (DevTools → Console in Electron window):
+
 ```
 IPC: GET_ALL - Fetching all blocks
 IPC: GET_ALL - Returning 4 blocks
@@ -37,21 +40,25 @@ Loading 4 blocks into Redux store
 ### 3. Verification Checklist
 
 ✅ **Electron Startup**:
+
 - [ ] App starts without errors
 - [ ] Console shows "Block service initialized successfully"
 - [ ] Console shows "BlockManager initialized with 4 blocks"
 
 ✅ **IPC Communication**:
+
 - [ ] DevTools console shows "IPC: GET_ALL - Returning 4 blocks"
 - [ ] No IPC errors in console
 
 ✅ **Redux Store**:
+
 - [ ] Open Redux DevTools
 - [ ] Find action: `@@graph_reducer/LOAD_LIBRARY_BLOCKS`
 - [ ] Verify `state.currentGraph.libraryBlocks` contains 4 blocks
 - [ ] Block objects have proper structure (name, description, ports, etc.)
 
 ✅ **Block Library UI**:
+
 - [ ] Open block library/search in the UI
 - [ ] Verify 4 blocks appear (not just 3):
   - Constant
@@ -64,11 +71,13 @@ Loading 4 blocks into Redux store
 ## Test Data Location
 
 JSON block files are located at:
+
 ```
 ~/Library/Application Support/CompX/block_storage/
 ```
 
 Current test blocks:
+
 - `test_block_constant.json` - Source block outputting constant value
 - `test_block_gain.json` - Multiplies input by gain factor
 - `test_block_integrator.json` - Continuous integration with initial condition
@@ -77,33 +86,40 @@ Current test blocks:
 ## Troubleshooting
 
 ### No Blocks Loaded
+
 **Symptom**: Console shows "BlockManager initialized with 0 blocks"
 
 **Check**:
+
 ```bash
 ls -la ~/Library/Application\ Support/CompX/block_storage/
 ```
 
 **Fix**: JSON files should be present. If not, they may have been deleted. Recreate with:
+
 ```bash
 # Copy test blocks from tmp if still available
 cp /tmp/test_block_*.json ~/Library/Application\ Support/CompX/block_storage/
 ```
 
 ### IPC Errors
+
 **Symptom**: Renderer console shows IPC errors or timeouts
 
 **Check**:
+
 1. Verify main process console shows IPC handlers registered
 2. Check for errors during BlockManager initialization
 3. Restart electron app to clear IPC state
 
 ### Still Shows 3 Blocks
+
 **Symptom**: Block library shows Constant, Sum, Multiply (hardcoded DefaultBlocks)
 
 **Root Cause**: Redux store still initialized with DefaultBlocks array
 
 **Verify Fix Applied**:
+
 ```bash
 grep -n "libraryBlocks:" packages/web_app/src/store/types.ts
 ```
@@ -111,9 +127,11 @@ grep -n "libraryBlocks:" packages/web_app/src/store/types.ts
 **Expected**: Should show `libraryBlocks: []` (empty array), NOT `[Constant, Sum, Multiply]`
 
 ### Redux Action Not Dispatched
+
 **Symptom**: No `LOAD_LIBRARY_BLOCKS` action in Redux DevTools
 
 **Check**:
+
 1. Verify BlockLibraryLoader component rendered
 2. Check for errors in useBlockLibrary hook
 3. Verify BlockServiceProvider wraps app in index.tsx
@@ -121,6 +139,7 @@ grep -n "libraryBlocks:" packages/web_app/src/store/types.ts
 ## Success Criteria
 
 ✅ **Implementation Successful** when:
+
 1. Electron app starts without errors
 2. Console shows 4 blocks loaded (not 0, not 3)
 3. IPC communication works (GET_ALL returns 4 blocks)
@@ -138,11 +157,13 @@ grep -n "libraryBlocks:" packages/web_app/src/store/types.ts
 ## Adding More Blocks
 
 To add custom blocks, create JSON files in:
+
 ```
 ~/Library/Application Support/CompX/block_storage/
 ```
 
 **Example - Sum block**:
+
 ```json
 {
   "schema_version": "1.0.0",
@@ -183,13 +204,17 @@ After adding blocks, restart the Electron app to load them.
 ## Debugging Commands
 
 ### Check Loaded Blocks
+
 **In Electron Main Process Console** (can add to BlockManager.ts temporarily):
+
 ```typescript
 console.log('Loaded blocks:', Array.from(this.blocks.keys()));
 ```
 
 ### Check IPC Communication
+
 **In Electron Renderer DevTools Console**:
+
 ```javascript
 // Test IPC directly
 const { ipcRenderer } = require('electron');
@@ -198,10 +223,12 @@ console.log('Blocks from IPC:', blocks);
 ```
 
 ### Check Redux State
+
 **In Redux DevTools**:
+
 ```javascript
 // View current state
-window.__REDUX_DEVTOOLS_EXTENSION__.getState().currentGraph.libraryBlocks
+window.__REDUX_DEVTOOLS_EXTENSION__.getState().currentGraph.libraryBlocks;
 ```
 
 ## References

--- a/claudedocs/TEST_COVERAGE_SUMMARY.md
+++ b/claudedocs/TEST_COVERAGE_SUMMARY.md
@@ -11,16 +11,19 @@ Created a comprehensive test suite with **100% coverage** for all new drag-and-d
 ## Test Files Created
 
 ### 1. Configuration Files
+
 - `packages/web_app/__tests__/jest.config.ts` - Jest configuration with jsdom environment
 - `packages/web_app/__tests__/setupTests.ts` - Test setup with Canvas API mocking
 
 ### 2. Test Suites
 
 #### `graphactions.test.ts` - Action Creator Tests
+
 - **6 test cases**
 - **Coverage**: 100% of AddBlockAction
 
 **What's tested:**
+
 - Action type correctness (`ADD_BLOCK`)
 - Payload structure (blockTemplate + position)
 - BlockTemplate property preservation
@@ -28,73 +31,87 @@ Created a comprehensive test suite with **100% coverage** for all new drag-and-d
 - Multiple action creation uniqueness
 
 #### `graphreducers.addblock.test.ts` - Reducer Tests
+
 - **29 test cases** across 6 describe blocks
 - **Coverage**: 100% of ADD_BLOCK reducer case
 
 **What's tested:**
 
-*Block Creation (5 tests)*
+_Block Creation (5 tests)_
+
 - Correct block structure with all visual properties
 - Unique ID generation for block and all ports
 - Multiple block addition without conflicts
 - ID uniqueness verification
 
-*Port Handling (1 test)*
+_Port Handling (1 test)_
+
 - Multi-port template preservation
 - Port types, names, and initial values
 - Port ID generation
 
-*Error Handling (3 tests)*
+_Error Handling (3 tests)_
+
 - Missing blockTemplate → state unchanged + warning
 - Null blockTemplate → state unchanged + warning
 - Undefined blockTemplate → state unchanged + warning
 
-*Position Handling (4 tests)*
+_Position Handling (4 tests)_
+
 - Positive coordinates
 - Negative coordinates
 - Zero coordinates
 - Large coordinate values (±10000)
 
-*State Immutability (2 tests)*
+_State Immutability (2 tests)_
+
 - Original state never mutated
 - Deep cloning verification
 - New state object creation
 
 #### `coordinates.test.ts` - Coordinate Transformation Tests
+
 - **21 test cases** across 8 describe blocks
 - **Coverage**: 100% of ScreenToWorld function
 
 **What's tested:**
 
-*Basic Transformations (3 tests)*
+_Basic Transformations (3 tests)_
+
 - Screen center → world origin
 - Corner coordinate mapping
 - Coordinate system verification
 
-*Zoom Transformations (4 tests)*
+_Zoom Transformations (4 tests)_
+
 - Zoom in (2x, 10x)
 - Zoom out (0.5x, 0.1x)
 - Scaling correctness
 
-*Translation Transformations (3 tests)*
+_Translation Transformations (3 tests)_
+
 - Positive pan (right, down)
 - Negative pan (left, up)
 - Large translation values
 
-*Combined Operations (2 tests)*
+_Combined Operations (2 tests)_
+
 - Zoom + translation together
 - Complex transformation scenarios
 
-*Y-Axis Inversion (2 tests)*
+_Y-Axis Inversion (2 tests)_
+
 - Screen down = world up
 - Inversion preserved with zoom
 
-*Edge Cases (3 tests)*
+_Edge Cases (3 tests)_
+
 - Zero-sized screen
 - Very small zoom values
 - Non-square dimensions
 
-*Real-World Scenarios (4 tests)*
+_Real-World Scenarios (4 tests)_
+
 - Drop at default position
 - Drop after panning canvas
 - Drop after zooming
@@ -102,30 +119,36 @@ Created a comprehensive test suite with **100% coverage** for all new drag-and-d
 
 ## Coverage Metrics
 
-| Metric | Target | Achieved |
-|--------|--------|----------|
-| Statements | 100% | ✅ 100% |
-| Branches | 100% | ✅ 100% |
-| Functions | 100% | ✅ 100% |
-| Lines | 100% | ✅ 100% |
+| Metric     | Target | Achieved |
+| ---------- | ------ | -------- |
+| Statements | 100%   | ✅ 100%  |
+| Branches   | 100%   | ✅ 100%  |
+| Functions  | 100%   | ✅ 100%  |
+| Lines      | 100%   | ✅ 100%  |
 
 ## Testing Best Practices Applied
 
 ### 1. **Immutability Verification**
+
 All reducer tests verify state immutability:
+
 ```typescript
 expect(newState).not.toBe(initialState);
 expect(initialState.blocks.length).toBe(originalCount); // Unchanged
 ```
 
 ### 2. **Floating-Point Precision**
+
 Coordinate tests use `toBeCloseTo()` for reliability:
+
 ```typescript
 expect(worldPos.x).toBeCloseTo(33.33, 2); // 2 decimal places
 ```
 
 ### 3. **Error Case Coverage**
+
 All error paths tested with console mocking:
+
 ```typescript
 const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 // ... test error case
@@ -134,7 +157,9 @@ consoleSpy.mockRestore();
 ```
 
 ### 4. **UUID Uniqueness**
+
 Block and port ID uniqueness verified:
+
 ```typescript
 const ids = [block.id, ...portIds];
 const uniqueIds = new Set(ids);
@@ -144,12 +169,14 @@ expect(uniqueIds.size).toBe(ids.length);
 ## Test Execution
 
 ### Run All Tests
+
 ```bash
 cd packages/web_app
 npm test
 ```
 
 ### Run Specific Suite
+
 ```bash
 npm test graphreducers.addblock
 npm test coordinates
@@ -157,12 +184,14 @@ npm test graphactions
 ```
 
 ### Generate Coverage Report
+
 ```bash
 npm test:coverage
 # Creates HTML report in packages/web_app/__tests__/coverage/
 ```
 
 ### Watch Mode (Development)
+
 ```bash
 npm test:watch
 ```
@@ -170,6 +199,7 @@ npm test:watch
 ## Dependencies Added
 
 Added to `packages/web_app/package.json` devDependencies:
+
 - `@testing-library/jest-dom`: ^5.16.5
 - `@testing-library/react`: ^13.3.0
 - `@types/jest`: ^29.0.0
@@ -181,16 +211,19 @@ Added to `packages/web_app/package.json` devDependencies:
 ## Key Features Tested
 
 ### ✅ Redux Flow
+
 - Action creation with correct types and payloads
 - Reducer state transformations
 - State immutability guarantees
 
 ### ✅ Block Creation
+
 - Visual block structure (position, size, shape, color)
 - Port generation with unique IDs
 - Template property preservation
 
 ### ✅ Coordinate Math
+
 - Screen-to-world transformations
 - Zoom scaling (in/out)
 - Pan translation
@@ -198,6 +231,7 @@ Added to `packages/web_app/package.json` devDependencies:
 - Combined transformations
 
 ### ✅ Error Handling
+
 - Missing/null/undefined inputs
 - Console warning verification
 - State preservation on errors
@@ -232,16 +266,19 @@ Tests are ready for CI/CD integration:
 ### Recommended Next Steps
 
 1. **Component Tests** (React Testing Library)
+
    - CardComponent drag interaction
    - LibraryViewer block rendering
    - CanvasContainer drop zones
 
 2. **Integration Tests**
+
    - End-to-end drag-and-drop flow
    - Multiple block scenarios
    - Block positioning accuracy
 
 3. **Performance Tests**
+
    - Coordinate transformation benchmarks
    - Large graph handling (100+ blocks)
    - Reducer performance under load

--- a/claudedocs/block-definition-system-design.md
+++ b/claudedocs/block-definition-system-design.md
@@ -29,6 +29,7 @@ This document outlines the migration from TypeScript-based block definitions to 
 ### Current System Limitations
 
 **TypeScript Block Definitions** (`packages/common/src/DefaultBlocks/`)
+
 - Blocks defined as TypeScript constants exported from `.ts` files
 - Requires compilation and application restart for any block changes
 - No support for runtime block loading or dynamic block packs
@@ -76,14 +77,14 @@ This document outlines the migration from TypeScript-based block definitions to 
 
 ### Key Architectural Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| **Loading Strategy** | File System Watcher | Enables dynamic block pack installation without restart |
-| **Validation** | JSON Schema | Industry standard, excellent tooling, type generation |
-| **Storage Format** | JSON | Human-readable, versionable, language-agnostic |
-| **Organization** | Category directories + tags | Balance between structure and searchability |
-| **Versioning** | Semantic versioning in schema | Enables migrations and backward compatibility |
-| **Platform Abstraction** | Service interface pattern | Future-proof for web server implementation |
+| Decision                 | Choice                        | Rationale                                               |
+| ------------------------ | ----------------------------- | ------------------------------------------------------- |
+| **Loading Strategy**     | File System Watcher           | Enables dynamic block pack installation without restart |
+| **Validation**           | JSON Schema                   | Industry standard, excellent tooling, type generation   |
+| **Storage Format**       | JSON                          | Human-readable, versionable, language-agnostic          |
+| **Organization**         | Category directories + tags   | Balance between structure and searchability             |
+| **Versioning**           | Semantic versioning in schema | Enables migrations and backward compatibility           |
+| **Platform Abstraction** | Service interface pattern     | Future-proof for web server implementation              |
 
 ---
 
@@ -94,6 +95,7 @@ This document outlines the migration from TypeScript-based block definitions to 
 **Purpose**: Define strict structure for block definitions with validation
 
 **Key Features**:
+
 - JSON Schema Draft 7 specification
 - Semantic versioning support (`schema_version`, `block_version`)
 - Port type definitions with initial values
@@ -101,6 +103,7 @@ This document outlines the migration from TypeScript-based block definitions to 
 - Validation rules for callback strings
 
 **Schema Fields**:
+
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -130,6 +133,7 @@ This document outlines the migration from TypeScript-based block definitions to 
 **Purpose**: Central registry for all available blocks with dynamic loading
 
 **Responsibilities**:
+
 - Initialize block registry on startup
 - Watch file system for block changes
 - Validate new/updated block definitions
@@ -137,6 +141,7 @@ This document outlines the migration from TypeScript-based block definitions to 
 - Notify frontend of library changes
 
 **Key Methods**:
+
 ```typescript
 interface BlockLibraryManager {
   // Initialization
@@ -162,16 +167,19 @@ interface BlockLibraryManager {
 **Purpose**: Monitor block directories for changes and trigger registry updates
 
 **Watched Directories**:
+
 - `packages/common/block_definitions/` - Core blocks (read-only)
 - `userData/custom_blocks/` - User-created blocks
 - `userData/block_packs/{pack-name}/` - Downloaded block packs
 
 **Events Handled**:
+
 - `add` - New block file detected
 - `change` - Existing block file modified
 - `unlink` - Block file deleted
 
 **Implementation Details**:
+
 - Use `chokidar` library (stable, cross-platform, feature-rich)
 - Debounce events (100ms) to handle rapid successive changes
 - Validate on change, update registry only if valid
@@ -184,11 +192,13 @@ interface BlockLibraryManager {
 **Validation Layers**:
 
 1. **JSON Schema Validation** (Structure)
+
    - Field presence and types
    - Enum value constraints
    - String format validation (hex colors, semver)
 
 2. **Semantic Validation** (Logic)
+
    - Port name uniqueness within block
    - Callback string syntax checking
    - Port type compatibility
@@ -200,6 +210,7 @@ interface BlockLibraryManager {
    - Warning for deprecated fields
 
 **Error Reporting**:
+
 ```typescript
 interface ValidationResult {
   valid: boolean;
@@ -219,6 +230,7 @@ interface ValidationError {
 **Purpose**: Decouple frontend from specific backend implementation (Electron vs Web)
 
 **Interface Design**:
+
 ```typescript
 // Frontend-facing interface (platform-agnostic)
 interface BlockService {
@@ -236,8 +248,12 @@ interface BlockService {
 }
 
 // Backend implementations
-class ElectronBlockService implements BlockService { /* IPC-based */ }
-class WebBlockService implements BlockService { /* HTTP-based */ }
+class ElectronBlockService implements BlockService {
+  /* IPC-based */
+}
+class WebBlockService implements BlockService {
+  /* HTTP-based */
+}
 ```
 
 ### 6. Frontend Block Service
@@ -245,12 +261,14 @@ class WebBlockService implements BlockService { /* HTTP-based */ }
 **Purpose**: Provide React components with block library access
 
 **Features**:
+
 - Singleton service instance
 - React hooks for block access (`useBlockLibrary`, `useBlock`)
 - Automatic re-rendering on library updates
 - Local caching for performance
 
 **Usage Example**:
+
 ```typescript
 // In React component
 const { blocks, loading, error } = useBlockLibrary();
@@ -268,6 +286,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Establish schema and validation infrastructure
 
 **Tasks**:
+
 1. Define JSON Schema for block definitions
 2. Create schema validation system with Ajv
 3. Write comprehensive schema tests
@@ -275,12 +294,14 @@ const gainBlock = useBlock('gain');
 5. Create migration guide from TS to JSON
 
 **Deliverables**:
+
 - `packages/common/src/BlockSchema/schema.json`
 - `packages/common/src/BlockSchema/validator.ts`
 - `packages/common/src/BlockSchema/__tests__/`
 - `claudedocs/block-schema-specification.md`
 
 **Success Criteria**:
+
 - Schema validates all existing block types
 - 100% test coverage for validation logic
 - Clear error messages for validation failures
@@ -292,18 +313,21 @@ const gainBlock = useBlock('gain');
 **Goal**: Set up block definition file structure
 
 **Tasks**:
+
 1. Create directory structure for block definitions
 2. Convert 1-2 existing blocks to JSON format (proof of concept)
 3. Implement block file loader (sync, startup-only version)
 4. Create build script to validate all blocks at build time
 
 **Deliverables**:
+
 - `packages/common/block_definitions/math/gain.json`
 - `packages/common/block_definitions/math/constant.json`
 - `packages/common/src/BlockLoader/FileLoader.ts`
 - `scripts/validate-blocks.js` (build-time validation)
 
 **Success Criteria**:
+
 - 2 blocks successfully loaded from JSON
 - Build fails if any block invalid
 - Directory structure supports category organization
@@ -315,6 +339,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Create in-memory registry with startup loading
 
 **Tasks**:
+
 1. Implement BlockLibraryManager class
 2. Build block registry (Map-based, searchable)
 3. Create initialization routine (load all blocks on startup)
@@ -322,11 +347,13 @@ const gainBlock = useBlock('gain');
 5. Write comprehensive unit tests
 
 **Deliverables**:
+
 - `packages/common/src/BlockLibrary/BlockLibraryManager.ts`
 - `packages/common/src/BlockLibrary/BlockRegistry.ts`
 - `packages/common/src/BlockLibrary/__tests__/`
 
 **Success Criteria**:
+
 - All blocks loaded into registry on startup
 - Search by name, tags, category works correctly
 - <100ms search performance for 1000 blocks
@@ -338,6 +365,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Enable dynamic block loading without restart
 
 **Tasks**:
+
 1. Integrate `chokidar` file system watcher
 2. Implement event handlers (add/change/unlink)
 3. Add debouncing for rapid file changes
@@ -346,10 +374,12 @@ const gainBlock = useBlock('gain');
 6. Write integration tests with temp directories
 
 **Deliverables**:
+
 - `packages/common/src/BlockLibrary/BlockWatcher.ts`
 - `packages/common/src/BlockLibrary/__tests__/watcher.test.ts`
 
 **Success Criteria**:
+
 - New block JSON detected within 200ms
 - Invalid blocks don't crash watcher
 - Multiple rapid changes handled correctly
@@ -362,6 +392,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Expose block library via Electron IPC
 
 **Tasks**:
+
 1. Update electron_loader to initialize BlockLibraryManager
 2. Create IPC handlers for block library API
 3. Implement event forwarding (library changes → renderer)
@@ -369,19 +400,23 @@ const gainBlock = useBlock('gain');
 5. Test with Electron app
 
 **Deliverables**:
+
 - `packages/electron_app/src/startup/BlockLibrarySetup.ts`
 - `packages/electron_app/src/ipc/BlockLibraryHandlers.ts`
 - Updated `packages/electron_app/src/index.ts`
 
 **API Methods** (IPC):
+
 - `block-library:get-all` → `BlockDefinition[]`
 - `block-library:get` (name) → `BlockDefinition | null`
 - `block-library:search` (query) → `BlockDefinition[]`
 
 **Events** (IPC):
+
 - `block-library:changed` → `LibraryChangeEvent`
 
 **Success Criteria**:
+
 - Blocks available via IPC within 1s of app start
 - File changes propagate to renderer within 500ms
 - No memory leaks from event listeners
@@ -393,6 +428,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Create platform-agnostic frontend API
 
 **Tasks**:
+
 1. Define BlockService interface
 2. Implement ElectronBlockService (IPC-based)
 3. Create React hooks (useBlockLibrary, useBlock)
@@ -400,12 +436,14 @@ const gainBlock = useBlock('gain');
 5. Write frontend tests with mocked service
 
 **Deliverables**:
+
 - `packages/web_app/src/services/BlockService/interface.ts`
 - `packages/web_app/src/services/BlockService/ElectronImpl.ts`
 - `packages/web_app/src/hooks/useBlockLibrary.ts`
 - `packages/web_app/src/services/BlockService/__tests__/`
 
 **Success Criteria**:
+
 - Frontend never directly calls Electron IPC
 - Easy to swap implementations (Electron → Web)
 - React components re-render on library updates
@@ -418,6 +456,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Update UI to use new block library system
 
 **Tasks**:
+
 1. Update block palette to use BlockService
 2. Modify block creation flow to use JSON definitions
 3. Update Redux actions/reducers for new format
@@ -425,11 +464,13 @@ const gainBlock = useBlock('gain');
 5. Test all block-related UI flows
 
 **Deliverables**:
+
 - Updated `packages/web_app/src/app/Container/BlockLibrary/`
 - Modified Redux actions in `packages/web_app/src/store/actions/graphactions.ts`
 - UI components for library status/errors
 
 **Success Criteria**:
+
 - Block palette shows all available blocks
 - Newly added blocks appear without refresh
 - Block creation works identically to before
@@ -442,6 +483,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Convert all existing TS blocks to JSON, deprecate old system
 
 **Tasks**:
+
 1. Convert all remaining DefaultBlocks to JSON format
 2. Verify functional equivalence with tests
 3. Update documentation and examples
@@ -450,12 +492,14 @@ const gainBlock = useBlock('gain');
 6. Add deprecation warnings
 
 **Deliverables**:
+
 - All blocks in `packages/common/block_definitions/`
 - `scripts/migrate-ts-block-to-json.js` utility
 - Updated `CLAUDE.md` with new block creation process
 - Deprecation notices in old code
 
 **Success Criteria**:
+
 - All 6+ core blocks converted to JSON
 - App works identically with JSON blocks
 - Clear migration path documented
@@ -468,6 +512,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Prepare for future web server implementation
 
 **Tasks**:
+
 1. Design HTTP API spec for block library
 2. Implement WebBlockService stub (returns mock data)
 3. Add platform detection and service selection
@@ -475,11 +520,13 @@ const gainBlock = useBlock('gain');
 5. Create API specification (OpenAPI/Swagger)
 
 **Deliverables**:
+
 - `packages/web_app/src/services/BlockService/WebImpl.ts` (stub)
 - `claudedocs/block-library-api-spec.yaml` (OpenAPI)
 - Platform detection in service factory
 
 **Success Criteria**:
+
 - WebBlockService implements full interface
 - Easy to swap between Electron and Web implementations
 - API spec complete and validated
@@ -492,6 +539,7 @@ const gainBlock = useBlock('gain');
 **Goal**: Comprehensive testing and production readiness
 
 **Tasks**:
+
 1. Write end-to-end tests for entire flow
 2. Performance testing (large block libraries)
 3. Error handling and edge case testing
@@ -500,6 +548,7 @@ const gainBlock = useBlock('gain');
 6. User acceptance testing
 
 **Test Scenarios**:
+
 - Load 1000 blocks on startup
 - Add block while app running
 - Update block definition while in use
@@ -510,12 +559,14 @@ const gainBlock = useBlock('gain');
 - Concurrent file changes
 
 **Deliverables**:
+
 - E2E test suite
 - Performance benchmarks
 - Security audit report
 - Updated documentation
 
 **Success Criteria**:
+
 - All tests passing
 - No memory leaks
 - Handles 1000+ blocks smoothly
@@ -528,6 +579,7 @@ const gainBlock = useBlock('gain');
 ### Block JSON Format
 
 **Example: Gain Block**
+
 ```json
 {
   "$schema": "./schema.json",
@@ -559,6 +611,7 @@ const gainBlock = useBlock('gain');
 ```
 
 **Example: Integrator Block (with initial value)**
+
 ```json
 {
   "$schema": "./schema.json",
@@ -593,6 +646,7 @@ const gainBlock = useBlock('gain');
 ### Port Type System
 
 **Supported Types**:
+
 - `NUMBER` - Scalar numeric value
 - `STRING` - Text string
 - `VECTOR` - 2D vector (future)
@@ -600,6 +654,7 @@ const gainBlock = useBlock('gain');
 - `BOOLEAN` - Boolean value (future)
 
 **Type Definitions** (unchanged from current system):
+
 ```typescript
 export const PortTypesStringList = ['STRING', 'NUMBER'] as const;
 
@@ -612,6 +667,7 @@ export interface PortTypes {
 ### Callback String Syntax
 
 **Available Variables**:
+
 - `inputPort[name]` - Current input port value
 - `prevInput[name]` - Previous input value (creates pseudo-source)
 - `prevOutput[name]` - Previous output value (for state)
@@ -620,21 +676,22 @@ export interface PortTypes {
 - `dt` - Time step
 
 **Example Callbacks**:
+
 ```javascript
 // Constant
-"return [5]"
+'return [5]';
 
 // Gain
-"return [inputPort[x] * 0.75]"
+'return [inputPort[x] * 0.75]';
 
 // Sum
-"return [inputPort[a] + inputPort[b]]"
+'return [inputPort[a] + inputPort[b]]';
 
 // Integrator (trapezoidal)
-"return [prevOutput[y] + dt * (prevInput[x] + inputPort[x]) / 2]"
+'return [prevOutput[y] + dt * (prevInput[x] + inputPort[x]) / 2]';
 
 // Scope (side effect)
-"console.log(inputPort[x]); return []"
+'console.log(inputPort[x]); return []';
 ```
 
 ### Directory Structure
@@ -678,6 +735,7 @@ packages/common/block_definitions/
 ### IPC API (Electron)
 
 **Channels**:
+
 ```typescript
 // Requests
 'block-library:get-all' → BlockDefinition[]
@@ -690,6 +748,7 @@ packages/common/block_definitions/
 ```
 
 **Type Definitions**:
+
 ```typescript
 interface BlockDefinition {
   schema_version: string;
@@ -705,15 +764,15 @@ interface BlockDefinition {
 }
 
 interface BlockSearchQuery {
-  name?: string;           // Partial match
-  tags?: string[];         // Any tag matches
-  category?: string;       // Exact match
+  name?: string; // Partial match
+  tags?: string[]; // Any tag matches
+  category?: string; // Exact match
 }
 
 interface LibraryChangeEvent {
   type: 'block-added' | 'block-updated' | 'block-removed';
   blockName: string;
-  block?: BlockDefinition;  // Present for add/update
+  block?: BlockDefinition; // Present for add/update
 }
 
 interface LibraryErrorEvent {
@@ -726,6 +785,7 @@ interface LibraryErrorEvent {
 ### HTTP API (Future Web Server)
 
 **Endpoints**:
+
 ```
 GET  /api/blocks              → List all blocks
 GET  /api/blocks/:name        → Get specific block
@@ -735,6 +795,7 @@ POST /api/block-packs/install → Install block pack (future)
 ```
 
 **Example Responses**:
+
 ```json
 // GET /api/blocks
 {
@@ -763,6 +824,7 @@ data: { "blockName": "gain", "block": { ... } }
 ### From TypeScript to JSON
 
 **Current Format** (TypeScript):
+
 ```typescript
 const gain: BlockStorageType<['NUMBER'], ['NUMBER']> = {
   name: 'gain',
@@ -776,6 +838,7 @@ export default gain;
 ```
 
 **New Format** (JSON):
+
 ```json
 {
   "$schema": "./schema.json",
@@ -797,6 +860,7 @@ export default gain;
 ```
 
 **Migration Steps**:
+
 1. Convert one block at a time
 2. Run tests to verify equivalence
 3. Update any block-specific UI references
@@ -805,6 +869,7 @@ export default gain;
 6. Update exports/imports
 
 **Automated Migration Script**:
+
 ```bash
 # Convert TS block to JSON
 npm run migrate-block -- packages/common/src/DefaultBlocks/Gain.ts
@@ -813,12 +878,14 @@ npm run migrate-block -- packages/common/src/DefaultBlocks/Gain.ts
 ### Backward Compatibility
 
 **During Transition** (Phases 1-7):
+
 - Both systems coexist
 - Old TS blocks still work
 - New JSON blocks loaded alongside
 - Gradual migration, no breaking changes
 
 **Post-Migration** (Phase 8+):
+
 - TS block system deprecated but functional
 - Warnings in console for TS block usage
 - All new blocks must be JSON
@@ -831,6 +898,7 @@ npm run migrate-block -- packages/common/src/DefaultBlocks/Gain.ts
 ### Unit Tests
 
 **Components to Test**:
+
 - JSON Schema validation
 - Block file parsing
 - Registry operations (add/update/remove/search)
@@ -839,6 +907,7 @@ npm run migrate-block -- packages/common/src/DefaultBlocks/Gain.ts
 - Frontend service implementations
 
 **Example Test Cases**:
+
 ```typescript
 describe('BlockValidator', () => {
   it('validates correct block definition', () => {
@@ -869,6 +938,7 @@ describe('BlockRegistry', () => {
 ### Integration Tests
 
 **Scenarios**:
+
 - Load all blocks from directory on startup
 - Add new block file and verify registry update
 - Modify block file and verify update propagation
@@ -876,6 +946,7 @@ describe('BlockRegistry', () => {
 - Invalid block doesn't crash system
 
 **Example**:
+
 ```typescript
 describe('Block Watcher Integration', () => {
   let tempDir: string;
@@ -901,6 +972,7 @@ describe('Block Watcher Integration', () => {
 ### End-to-End Tests
 
 **Full User Flows**:
+
 1. Start app → blocks loaded → palette shows all blocks
 2. Drag block to canvas → instantiation works
 3. Add new block JSON file → appears in palette within 1s
@@ -908,6 +980,7 @@ describe('Block Watcher Integration', () => {
 5. Delete block → removed from palette
 
 **Tools**:
+
 - Playwright for Electron app testing
 - Jest for unit/integration tests
 - Custom test utilities for temp file system
@@ -921,6 +994,7 @@ describe('Block Watcher Integration', () => {
 **Target**: App ready in <2 seconds
 
 **Optimizations**:
+
 - Lazy load block details (load index first, details on demand)
 - Parallel JSON parsing
 - Index cache in userData (invalidate on directory change)
@@ -929,12 +1003,14 @@ describe('Block Watcher Integration', () => {
 ### Runtime Performance
 
 **Targets**:
+
 - Block search: <50ms for 1000 blocks
 - File change detection: <200ms
 - Registry update: <10ms
 - Frontend notification: <100ms
 
 **Optimizations**:
+
 - In-memory Map-based registry (O(1) lookup)
 - Debounced file system events
 - Incremental index updates (not full rebuild)
@@ -943,12 +1019,14 @@ describe('Block Watcher Integration', () => {
 ### Memory Management
 
 **Considerations**:
+
 - Each block definition: ~1-5KB
 - 1000 blocks = ~1-5MB memory (acceptable)
 - Registry overhead: minimal (Map + indexes)
 - Watcher overhead: <1MB
 
 **Monitoring**:
+
 - Track registry size
 - Monitor event listener count
 - Check for memory leaks in watcher
@@ -960,11 +1038,13 @@ describe('Block Watcher Integration', () => {
 ### File System Access
 
 **Risks**:
+
 - Malicious block definitions (arbitrary code in callbacks)
 - Path traversal attacks
 - Symlink attacks
 
 **Mitigations**:
+
 - Validate all file paths before reading
 - Restrict write access to userData only
 - Sanitize callback strings (AST parsing, not eval)
@@ -974,10 +1054,12 @@ describe('Block Watcher Integration', () => {
 ### Validation Bypass
 
 **Risks**:
+
 - Invalid blocks loaded into registry
 - Schema validation disabled
 
 **Mitigations**:
+
 - Always validate before adding to registry
 - No way to disable validation in production
 - Log all validation failures
@@ -988,6 +1070,7 @@ describe('Block Watcher Integration', () => {
 **Current Risk**: Callback strings use `eval` (Function constructor)
 
 **Future Mitigation** (Phase 10+):
+
 - AST parsing and validation
 - Whitelist of allowed operations
 - VM sandbox for callback execution
@@ -1000,24 +1083,28 @@ describe('Block Watcher Integration', () => {
 ### Phase 10+: Advanced Features
 
 **Block Pack Ecosystem**:
+
 - Block pack marketplace
 - Automated installation/updates
 - Dependency management
 - Digital signatures for verification
 
 **Block Development Tools**:
+
 - Visual callback editor
 - Block testing framework
 - Interactive block simulator
 - Documentation generator
 
 **Performance Enhancements**:
+
 - Compiled callbacks (WebAssembly)
 - Block caching strategies
 - Lazy block loading
 - Virtual scrolling in block palette
 
 **Collaboration Features**:
+
 - Shared block libraries
 - Version control integration
 - Team block repositories
@@ -1068,11 +1155,12 @@ packages/web_app/src/
 ### B. Dependencies
 
 **New Dependencies**:
+
 ```json
 {
-  "chokidar": "^3.5.3",          // File system watcher
-  "ajv": "^8.12.0",              // JSON Schema validation
-  "ajv-formats": "^2.1.1"        // Additional format validators
+  "chokidar": "^3.5.3", // File system watcher
+  "ajv": "^8.12.0", // JSON Schema validation
+  "ajv-formats": "^2.1.1" // Additional format validators
 }
 ```
 
@@ -1101,9 +1189,9 @@ BLOCK_CACHE_ENABLED=true         # Enable index cache
 
 ## Document History
 
-| Version | Date | Author | Changes |
-|---------|------|--------|---------|
-| 1.0 | 2025-10-27 | System | Initial design document |
+| Version | Date       | Author | Changes                 |
+| ------- | ---------- | ------ | ----------------------- |
+| 1.0     | 2025-10-27 | System | Initial design document |
 
 ---
 

--- a/claudedocs/block-library-manager-implementation.md
+++ b/claudedocs/block-library-manager-implementation.md
@@ -13,6 +13,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 **Purpose**: In-memory storage and search for block definitions with O(1) lookups
 
 **Key Features**:
+
 - Map-based primary storage for fast block retrieval by name
 - Category and tag indexes for efficient filtering
 - Comprehensive search capabilities (name, category, tags, version)
@@ -20,6 +21,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 - Statistics tracking (total blocks, blocks by category, all tags)
 
 **Performance**:
+
 - O(1) lookup by name
 - O(n) search operations with indexed filtering
 - Efficient memory usage with shared index structures
@@ -29,6 +31,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 **Purpose**: Central registry for all available blocks with validation and event notification
 
 **Key Features**:
+
 - Initialization lifecycle management
 - Comprehensive block validation (JSON Schema + semantic checks)
 - Event-driven architecture with EventEmitter
@@ -37,6 +40,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 - Singleton pattern support via `getDefaultManager()`
 
 **Event System**:
+
 - `library-initialized`: Emitted when library finishes initialization
 - `block-added`: Emitted when a new block is added
 - `block-updated`: Emitted when an existing block is updated
@@ -44,6 +48,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 - `library-error`: Emitted on validation or operation errors
 
 **Event Listener Methods**:
+
 - `addEventListener(event, callback)`: Register listener, returns unsubscribe function
 - `addEventListenerOnce(event, callback)`: Register one-time listener
 - `removeEventListener(event, callback)`: Unregister listener
@@ -53,6 +58,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 **Purpose**: TypeScript type safety for the library system
 
 **Key Types**:
+
 - `BlockSearchQuery`: Search criteria for finding blocks
 - `LibraryEventType`: Union type of all event types
 - `LibraryChangeEvent`: Event data for block changes
@@ -62,6 +68,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 ### 4. Comprehensive Test Suite
 
 **BlockRegistry Tests** (`__tests__/BlockLibrary/BlockRegistry.test.ts`):
+
 - ✅ Basic operations (add, update, remove, clear)
 - ✅ Search operations (name, category, tags, version)
 - ✅ Category operations (get by category, list all)
@@ -70,6 +77,7 @@ This implementation completes **Phase 2** of the JSON-Based Block Definition Sys
 - ✅ Edge cases and error handling
 
 **BlockLibraryManager Tests** (`__tests__/BlockLibrary/BlockLibraryManager.test.ts`):
+
 - ✅ Initialization lifecycle
 - ✅ Block operations (add, update, remove)
 - ✅ Search and query operations
@@ -122,7 +130,7 @@ registry.remove('scope');
 
 // Search
 const results = registry.search({
-  name: 'gai',  // Partial, case-insensitive
+  name: 'gai', // Partial, case-insensitive
   category: 'math',
   tags: ['linear', 'scaling']
 });
@@ -166,26 +174,31 @@ import {
 This implementation focuses on the core registry and event system. The following are planned for future phases:
 
 ❌ **File System Watcher** (Phase 3)
+
 - Dynamic loading of blocks from filesystem
 - Chokidar integration for file monitoring
 - Hot-reload capabilities
 
 ❌ **File Loader** (Phase 1)
+
 - Loading blocks from JSON files
 - Directory scanning and organization
 - Build-time validation
 
 ❌ **Electron Integration** (Phase 4)
+
 - IPC handlers for block library API
 - Renderer process event forwarding
 - UserData directory setup
 
 ❌ **Frontend Service Layer** (Phase 5)
+
 - Platform-agnostic service interface
 - React hooks (useBlockLibrary, useBlock)
 - Service initialization
 
 ❌ **Frontend Integration** (Phase 6)
+
 - Block palette updates
 - Redux integration
 - UI for library status
@@ -211,12 +224,14 @@ npm test -- --coverage
 
 **Decision**: Use Node.js EventEmitter for event system
 **Rationale**:
+
 - Well-established pattern in Node/Electron ecosystem
 - Type-safe with custom event types
 - Easy to test and understand
 - Supports multiple listeners per event
 
 **Trade-off**:
+
 - Method name conflicts with EventEmitter base class
 - Solution: Renamed methods to `addEventListener`, `removeEventListener`, `addEventListenerOnce`
 
@@ -224,6 +239,7 @@ npm test -- --coverage
 
 **Decision**: Use Map for primary block storage
 **Rationale**:
+
 - O(1) lookup by name (critical for common operation)
 - Native JavaScript data structure
 - Better performance than object for frequent add/remove
@@ -233,6 +249,7 @@ npm test -- --coverage
 
 **Decision**: Maintain separate indexes for categories and tags
 **Rationale**:
+
 - Efficient search without full registry scan
 - Trade memory for speed
 - Automatic cleanup keeps indexes synchronized
@@ -241,6 +258,7 @@ npm test -- --coverage
 
 **Decision**: Integrate existing BlockValidator from BlockSchema
 **Rationale**:
+
 - Reuse existing, tested validation logic
 - Consistency across JSON and runtime blocks
 - Semantic validation beyond schema
@@ -249,6 +267,7 @@ npm test -- --coverage
 
 **Decision**: Support both strict and non-strict validation
 **Rationale**:
+
 - Development: non-strict allows warnings
 - Production: strict enforces quality
 - User choice for different contexts
@@ -272,6 +291,7 @@ packages/common/
 ## Dependencies
 
 No new dependencies required! Uses existing:
+
 - `events` (Node.js built-in)
 - `ajv` and `ajv-formats` (already added for BlockSchema)
 
@@ -280,6 +300,7 @@ No new dependencies required! Uses existing:
 To continue implementation according to the design document:
 
 ### Immediate Next Phase (Phase 3 - File System Watcher)
+
 1. Add `chokidar` dependency
 2. Create `BlockWatcher.ts` for file system monitoring
 3. Implement debounced file change handling
@@ -287,17 +308,21 @@ To continue implementation according to the design document:
 5. Connect watcher to BlockLibraryManager
 
 ### Recommended Order
+
 1. **Phase 1**: File Storage & Organization
+
    - Create block definition directories
    - Convert sample blocks to JSON
    - Implement FileLoader
 
 2. **Phase 3**: File System Watcher
+
    - Integrate chokidar
    - Connect to BlockLibraryManager
    - Test hot-reload scenarios
 
 3. **Phase 4**: Electron Integration
+
    - IPC handlers
    - Event forwarding
    - userData setup

--- a/claudedocs/block-schema-quick-reference.md
+++ b/claudedocs/block-schema-quick-reference.md
@@ -47,24 +47,25 @@
 
 ## Field Reference
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `schema_version` | string | ✅ | Schema version (semver: "1.0.0") |
-| `name` | string | ✅ | Unique block identifier (lowercase, underscores) |
-| `version` | string | ✅ | Block version (semver: "1.0.0") |
-| `description` | string | ⚠️ | Human-readable description (max 500 chars) |
-| `category` | string | ⚠️ | Category for organization (lowercase, underscores) |
-| `tags` | array | ⚠️ | Search tags (max 10, lowercase with hyphens) |
-| `inputPorts` | array | ✅ | Input port definitions (max 20) |
-| `outputPorts` | array | ✅ | Output port definitions (max 20) |
-| `callbackString` | string | ✅ | JavaScript computation (1-10,000 chars) |
-| `visual` | object | ❌ | Visual styling properties |
+| Field            | Type   | Required | Description                                        |
+| ---------------- | ------ | -------- | -------------------------------------------------- |
+| `schema_version` | string | ✅       | Schema version (semver: "1.0.0")                   |
+| `name`           | string | ✅       | Unique block identifier (lowercase, underscores)   |
+| `version`        | string | ✅       | Block version (semver: "1.0.0")                    |
+| `description`    | string | ⚠️       | Human-readable description (max 500 chars)         |
+| `category`       | string | ⚠️       | Category for organization (lowercase, underscores) |
+| `tags`           | array  | ⚠️       | Search tags (max 10, lowercase with hyphens)       |
+| `inputPorts`     | array  | ✅       | Input port definitions (max 20)                    |
+| `outputPorts`    | array  | ✅       | Output port definitions (max 20)                   |
+| `callbackString` | string | ✅       | JavaScript computation (1-10,000 chars)            |
+| `visual`         | object | ❌       | Visual styling properties                          |
 
 ✅ Required | ⚠️ Recommended | ❌ Optional
 
 ## Port Definitions
 
 ### Input Port
+
 ```json
 {
   "name": "x",
@@ -74,6 +75,7 @@
 ```
 
 ### Output Port
+
 ```json
 {
   "name": "y",
@@ -82,6 +84,7 @@
 ```
 
 ### Port Types
+
 - `NUMBER` - Scalar numeric value
 - `STRING` - Text string
 - `VECTOR` - 2D vector (future)
@@ -93,9 +96,9 @@
 ```json
 {
   "visual": {
-    "color": "#RRGGBB",      // Hex color (e.g., "#4CAF50")
-    "icon": "icon-name",     // Icon identifier
-    "shape": "rect"          // "rect", "circ", or "tri"
+    "color": "#RRGGBB", // Hex color (e.g., "#4CAF50")
+    "icon": "icon-name", // Icon identifier
+    "shape": "rect" // "rect", "circ", or "tri"
   }
 }
 ```
@@ -103,6 +106,7 @@
 ## Callback String Syntax
 
 ### Available Variables
+
 - `inputPort[name]` - Current input port value
 - `prevInput[name]` - Previous input value (requires initialValue)
 - `prevOutput[name]` - Previous output value (for state)
@@ -113,48 +117,57 @@
 ### Examples
 
 **Constant**:
+
 ```javascript
-return [5]
+return [5];
 ```
 
 **Gain**:
+
 ```javascript
-return [inputPort[x] * 0.75]
+return [inputPort[x] * 0.75];
 ```
 
 **Sum**:
+
 ```javascript
-return [inputPort[a] + inputPort[b]]
+return [inputPort[a] + inputPort[b]];
 ```
 
 **Integrator** (requires initialValue):
+
 ```javascript
-return [prevOutput[y] + dt * (prevInput[x] + inputPort[x]) / 2]
+return [prevOutput[y] + (dt * (prevInput[x] + inputPort[x])) / 2];
 ```
 
 **Scope** (sink with side effects):
+
 ```javascript
 console.log('Value:', inputPort[x]);
-return []
+return [];
 ```
 
 ## Validation Rules
 
 ### Name Patterns
+
 - **Block name**: `^[a-z][a-z0-9_]*$` (lowercase, alphanumeric, underscores)
 - **Port name**: `^[a-zA-Z][a-zA-Z0-9_]*$` (alphanumeric, underscores)
 - **Category**: `^[a-z][a-z0-9_]*$` (lowercase, alphanumeric, underscores)
 - **Tag**: `^[a-z][a-z0-9_-]*$` (lowercase, alphanumeric, underscores, hyphens)
 
 ### Version Format
+
 - Must be semantic versioning: `major.minor.patch` (e.g., "1.0.0", "2.1.3")
 
 ### Visual Color
+
 - Must be hex color: `#RRGGBB` (e.g., "#4CAF50", "#FF5722")
 
 ## Common Validation Errors
 
 ### Invalid Name
+
 ```json
 {"name": "MyBlock"}  // ❌ Uppercase not allowed
 {"name": "my-block"} // ❌ Hyphens not allowed
@@ -162,6 +175,7 @@ return []
 ```
 
 ### Invalid Version
+
 ```json
 {"version": "v1.0"}     // ❌ No 'v' prefix
 {"version": "1.0"}      // ❌ Must have patch version
@@ -169,53 +183,57 @@ return []
 ```
 
 ### Invalid Port Reference
+
 ```json
 {
-  "inputPorts": [{"name": "x", "type": "NUMBER"}],
-  "callbackString": "return [inputPort[y]]"  // ❌ 'y' doesn't exist
+  "inputPorts": [{ "name": "x", "type": "NUMBER" }],
+  "callbackString": "return [inputPort[y]]" // ❌ 'y' doesn't exist
 }
 ```
 
 ### Missing Initial Value
+
 ```json
 {
-  "inputPorts": [{"name": "x", "type": "NUMBER"}],
-  "callbackString": "return [prevInput[x]]"  // ❌ Need initialValue for prevInput
+  "inputPorts": [{ "name": "x", "type": "NUMBER" }],
+  "callbackString": "return [prevInput[x]]" // ❌ Need initialValue for prevInput
 }
 ```
 
 **Correct**:
+
 ```json
 {
-  "inputPorts": [{"name": "x", "type": "NUMBER", "initialValue": 0}],
-  "callbackString": "return [prevInput[x]]"  // ✅ Has initialValue
+  "inputPorts": [{ "name": "x", "type": "NUMBER", "initialValue": 0 }],
+  "callbackString": "return [prevInput[x]]" // ✅ Has initialValue
 }
 ```
 
 ## TypeScript Usage
 
 ### Import
+
 ```typescript
-import {
-  BlockDefinition,
-  validateBlock,
-  CURRENT_SCHEMA_VERSION
-} from '@compx/common/BlockSchema';
+import { BlockDefinition, validateBlock, CURRENT_SCHEMA_VERSION } from '@compx/common/BlockSchema';
 ```
 
 ### Validate
+
 ```typescript
-const block: BlockDefinition = { /* ... */ };
+const block: BlockDefinition = {
+  /* ... */
+};
 const result = validateBlock(block);
 
 if (!result.valid) {
-  result.errors.forEach(err => {
+  result.errors.forEach((err) => {
     console.error(`${err.field}: ${err.message}`);
   });
 }
 ```
 
 ### Create Block
+
 ```typescript
 const myBlock: BlockDefinition = {
   schema_version: CURRENT_SCHEMA_VERSION,
@@ -224,12 +242,8 @@ const myBlock: BlockDefinition = {
   description: 'My custom block',
   category: 'custom',
   tags: ['custom', 'example'],
-  inputPorts: [
-    { name: 'input', type: 'NUMBER' }
-  ],
-  outputPorts: [
-    { name: 'output', type: 'NUMBER' }
-  ],
+  inputPorts: [{ name: 'input', type: 'NUMBER' }],
+  outputPorts: [{ name: 'output', type: 'NUMBER' }],
   callbackString: 'return [inputPort[input] * 2]',
   visual: {
     color: '#9C27B0',
@@ -242,6 +256,7 @@ const myBlock: BlockDefinition = {
 ## File Organization
 
 ### Recommended Structure
+
 ```
 block_definitions/
 ├── math/
@@ -256,6 +271,7 @@ block_definitions/
 ```
 
 ### File Naming
+
 - Use lowercase with underscores
 - Match block name: `gain.json` for block named "gain"
 - One block per file
@@ -263,6 +279,7 @@ block_definitions/
 ## Programmatic Validation
 
 ### Load and Validate
+
 ```typescript
 import * as fs from 'fs';
 import { validateBlock } from '@compx/common/BlockSchema';
@@ -279,21 +296,22 @@ if (result.valid) {
 ```
 
 ### Batch Validation
+
 ```typescript
 import { glob } from 'glob';
 
 const blockFiles = glob.sync('block_definitions/**/*.json');
-const results = blockFiles.map(file => {
+const results = blockFiles.map((file) => {
   const block = JSON.parse(fs.readFileSync(file, 'utf8'));
   return { file, result: validateBlock(block) };
 });
 
-const invalid = results.filter(r => !r.result.valid);
+const invalid = results.filter((r) => !r.result.valid);
 if (invalid.length > 0) {
   console.error(`❌ ${invalid.length} invalid blocks`);
   invalid.forEach(({ file, result }) => {
     console.error(`\n${file}:`);
-    result.errors.forEach(err => console.error(`  - ${err.message}`));
+    result.errors.forEach((err) => console.error(`  - ${err.message}`));
   });
   process.exit(1);
 }

--- a/claudedocs/phase-0-implementation-summary.md
+++ b/claudedocs/phase-0-implementation-summary.md
@@ -8,6 +8,7 @@
 ### 1. JSON Schema Definition (`packages/common/src/BlockSchema/schema.json`)
 
 Complete JSON Schema Draft 7 specification for block definitions with:
+
 - Semantic versioning support (`schema_version: 1.0.0`)
 - Strict validation rules for all fields
 - Port type system (NUMBER, STRING, VECTOR, MATRIX, BOOLEAN)
@@ -15,6 +16,7 @@ Complete JSON Schema Draft 7 specification for block definitions with:
 - Comprehensive field validation (patterns, enums, limits)
 
 **Key Features**:
+
 - Port name uniqueness enforced via pattern matching
 - Hex color validation for visual properties
 - Callback string length limits (1-10,000 chars)
@@ -23,6 +25,7 @@ Complete JSON Schema Draft 7 specification for block definitions with:
 ### 2. TypeScript Type Definitions (`packages/common/src/BlockSchema/types.ts`)
 
 Type-safe interfaces matching the JSON Schema:
+
 - `BlockDefinition` - Main block structure
 - `PortDefinition` - Input port with optional initialValue
 - `OutputPortDefinition` - Output port definition
@@ -31,6 +34,7 @@ Type-safe interfaces matching the JSON Schema:
 - `ValidationError` - Detailed error information
 
 **Helper Functions**:
+
 - Type guards: `isBlockDefinition()`, `isPortDefinition()`
 - Default values: `BLOCK_DEFAULTS`, `PORT_TYPE_DEFAULTS`
 - Current schema version constant
@@ -40,12 +44,14 @@ Type-safe interfaces matching the JSON Schema:
 Multi-layer validation system with Ajv:
 
 **JSON Schema Validation**:
+
 - Field presence and types
 - Pattern matching for names, versions, colors
 - Enum constraints for types and shapes
 - Array size limits
 
 **Semantic Validation**:
+
 - Port name uniqueness check
 - Callback string JavaScript syntax validation
 - Port reference validation (inputPort[], prevInput[], prevOutput[])
@@ -53,11 +59,13 @@ Multi-layer validation system with Ajv:
 - prevInput[] requires initialValue enforcement
 
 **Warning System**:
+
 - Missing descriptions
 - Missing tags
 - Schema version mismatches
 
 **API**:
+
 ```typescript
 const validator = new BlockValidator();
 const result = validator.validate(blockDefinition);
@@ -67,6 +75,7 @@ const result = validator.validate(blockDefinition);
 ### 4. Comprehensive Test Suite (`packages/common/__tests__/BlockSchema/validator.test.ts`)
 
 20 test cases covering:
+
 - ✅ Valid block definitions (constant, gain, integrator, minimal)
 - ❌ Schema violations (invalid names, versions, types, colors, shapes)
 - ❌ Semantic errors (duplicate ports, invalid references, syntax errors)
@@ -79,6 +88,7 @@ const result = validator.validate(blockDefinition);
 Six JSON block definitions created in `packages/common/block_definitions/`:
 
 **Math Category** (`math/`):
+
 - `constant.json` - Constant source block
 - `gain.json` - Signal multiplier
 - `integrator.json` - Continuous integrator with state
@@ -86,9 +96,11 @@ Six JSON block definitions created in `packages/common/block_definitions/`:
 - `multiply.json` - Two-input multiplier
 
 **IO Category** (`io/`):
+
 - `scope.json` - Console logging sink
 
 All blocks validated against schema and include:
+
 - Semantic versioning
 - Descriptions and tags
 - Visual styling (color, icon, shape)
@@ -122,19 +134,21 @@ packages/common/
 
 ```json
 {
-  "ajv": "^8.12.0",           // JSON Schema validator
-  "ajv-formats": "^2.1.1"     // Additional format validators
+  "ajv": "^8.12.0", // JSON Schema validator
+  "ajv-formats": "^2.1.1" // Additional format validators
 }
 ```
 
 ## Configuration Changes
 
 **tsconfig.json**:
+
 - Added `"resolveJsonModule": true` to enable JSON imports
 
 ## Validation Examples
 
 ### Valid Block
+
 ```json
 {
   "schema_version": "1.0.0",
@@ -143,8 +157,8 @@ packages/common/
   "description": "Multiplies input by constant",
   "category": "math",
   "tags": ["math", "linear"],
-  "inputPorts": [{"name": "x", "type": "NUMBER"}],
-  "outputPorts": [{"name": "y", "type": "NUMBER"}],
+  "inputPorts": [{ "name": "x", "type": "NUMBER" }],
+  "outputPorts": [{ "name": "y", "type": "NUMBER" }],
   "callbackString": "return [inputPort[x] * 0.75]",
   "visual": {
     "color": "#4CAF50",
@@ -155,6 +169,7 @@ packages/common/
 ```
 
 ### Schema Errors Detected
+
 - ❌ Invalid name pattern (must be lowercase with underscores)
 - ❌ Invalid version format (must be semver x.y.z)
 - ❌ Invalid port types (must be NUMBER, STRING, etc.)
@@ -162,6 +177,7 @@ packages/common/
 - ❌ Invalid shape (must be rect, circ, or tri)
 
 ### Semantic Errors Detected
+
 - ❌ Duplicate port names
 - ❌ Reference to non-existent ports
 - ❌ prevInput[] without initialValue
@@ -169,6 +185,7 @@ packages/common/
 - ❌ Type mismatch in initial values
 
 ### Warnings Issued
+
 - ⚠️ Missing description
 - ⚠️ Missing tags
 - ⚠️ Schema version mismatch
@@ -179,7 +196,9 @@ packages/common/
 import { validateBlock, BlockDefinition } from '@compx/common/BlockSchema';
 
 // Validate a block definition
-const block: BlockDefinition = { /* ... */ };
+const block: BlockDefinition = {
+  /* ... */
+};
 const result = validateBlock(block);
 
 if (result.valid) {

--- a/claudedocs/test-coverage-summary.md
+++ b/claudedocs/test-coverage-summary.md
@@ -6,32 +6,35 @@
 
 ## Test Suites
 
-| Test Suite | Tests | Status |
-|-----------|-------|--------|
-| **validator.test.ts** | 20 | ✅ Pass |
-| **schema-edge-cases.test.ts** | 43 | ✅ Pass |
-| **callback-validation.test.ts** | 30 | ✅ Pass |
-| **block-files-integration.test.ts** | 27 | ✅ Pass |
-| **graph.test.ts** | 18 | ✅ Pass |
-| **block.test.ts** | 9 | ✅ Pass |
-| **port.test.ts** | 8 | ✅ Pass |
-| **error_handling.test.ts** | 5 | ✅ Pass |
-| **edge.test.ts** | 5 | ✅ Pass |
+| Test Suite                          | Tests | Status  |
+| ----------------------------------- | ----- | ------- |
+| **validator.test.ts**               | 20    | ✅ Pass |
+| **schema-edge-cases.test.ts**       | 43    | ✅ Pass |
+| **callback-validation.test.ts**     | 30    | ✅ Pass |
+| **block-files-integration.test.ts** | 27    | ✅ Pass |
+| **graph.test.ts**                   | 18    | ✅ Pass |
+| **block.test.ts**                   | 9     | ✅ Pass |
+| **port.test.ts**                    | 8     | ✅ Pass |
+| **error_handling.test.ts**          | 5     | ✅ Pass |
+| **edge.test.ts**                    | 5     | ✅ Pass |
 
 **Total**: 9 test suites, 165 tests
 
 ## New Tests Added (100 tests)
 
 ### 1. Core Validator Tests (20 tests)
+
 **File**: `__tests__/BlockSchema/validator.test.ts`
 
 **Valid Block Definitions** (4 tests):
+
 - ✅ Simple constant block
 - ✅ Gain block with I/O
 - ✅ Integrator with initial value
 - ✅ Minimal block (required fields only)
 
 **Schema Validation Errors** (6 tests):
+
 - ❌ Missing required fields
 - ❌ Invalid name pattern (uppercase, hyphens)
 - ❌ Invalid version format
@@ -40,6 +43,7 @@
 - ❌ Invalid shape enum
 
 **Semantic Validation** (7 tests):
+
 - ❌ Duplicate port names
 - ❌ Reference to non-existent input port
 - ❌ prevInput without initialValue
@@ -48,14 +52,17 @@
 - ❌ Type mismatch in initial values
 
 **Warnings** (3 tests):
+
 - ⚠️ Missing description
 - ⚠️ Missing tags
 - ⚠️ Schema version mismatch
 
 ### 2. Edge Case Tests (43 tests)
+
 **File**: `__tests__/BlockSchema/schema-edge-cases.test.ts`
 
 **String Length Boundaries** (6 tests):
+
 - ✅ Max block name (64 chars)
 - ❌ Exceeds max name (65 chars)
 - ✅ Max description (500 chars)
@@ -64,6 +71,7 @@
 - ❌ Empty callback
 
 **Array Boundaries** (7 tests):
+
 - ✅ Max input ports (20)
 - ❌ Too many input ports (21)
 - ✅ Max output ports (20)
@@ -72,12 +80,14 @@
 - ❌ Duplicate tags
 
 **Port Name Patterns** (5 tests):
+
 - ✅ Uppercase port names
 - ✅ Underscore port names
 - ❌ Port names starting with number
 - ❌ Port names with hyphens
 
 **Callback Edge Cases** (5 tests):
+
 - ✅ Multi-line callbacks
 - ✅ Callbacks with comments
 - ✅ Multiple return statements
@@ -85,32 +95,38 @@
 - ❌ Invalid JavaScript operators
 
 **Initial Value Type Matching** (8 tests):
+
 - ✅ Number for NUMBER port (42, -42.5, 0)
 - ✅ String for STRING port
 - ✅ Empty string for STRING port
 - ✅ Boolean for BOOLEAN port
 
 **Port Reference Validation** (4 tests):
+
 - ❌ Multiple references to non-existent port
 - ✅ Dot notation for port access
 - ❌ Invalid dot notation reference
 - ✅ Mixed bracket and dot notation
 
 **Special Characters** (5 tests):
+
 - ✅ Port names with numbers
 - ❌ Unicode characters in names
 - ✅ Valid hex colors (5 variations)
 - ❌ Invalid hex formats (5 variations)
 
 **Additional Properties** (3 tests):
+
 - ❌ Unexpected top-level property
 - ❌ Unexpected port property
 - ❌ Unexpected visual property
 
 ### 3. Callback Validation Tests (30 tests)
+
 **File**: `__tests__/BlockSchema/callback-validation.test.ts`
 
 **Port Reference Extraction** (5 tests):
+
 - ✅ Single inputPort reference
 - ✅ Multiple inputPort references
 - ✅ prevOutput references
@@ -118,6 +134,7 @@
 - ❌ prevInput without initialValue
 
 **Complex Callback Patterns** (5 tests):
+
 - ✅ Integrator (trapezoidal rule)
 - ✅ PID controller logic
 - ✅ State machine
@@ -125,6 +142,7 @@
 - ✅ Conditional logic (saturator)
 
 **Invalid Callback Patterns** (6 tests):
+
 - ❌ Non-existent input reference
 - ❌ Non-existent output in prevOutput
 - ❌ Multiple undefined references
@@ -133,26 +151,31 @@
 - ❌ Missing semicolon
 
 **Edge Cases in Port References** (3 tests):
+
 - ✅ Port names that are substrings
 - ✅ Mixed case port names
 - ❌ Case-sensitive mismatches
 
 **Callbacks with No Port References** (5 tests):
+
 - ✅ Only constants
 - ✅ Using t (time) variable
 - ✅ Using dt (time step)
 - ✅ Math.random()
 
 **Callback Return Validation** (6 tests):
+
 - ✅ Returning array
 - ✅ No return (sink block)
 - ✅ Empty array for sink
 - ✅ Multiple return values
 
 ### 4. Integration Tests (27 tests)
+
 **File**: `__tests__/BlockSchema/block-files-integration.test.ts`
 
 **Example Block Files** (18 tests, 3 per block):
+
 - ✅ math/constant.json validation
 - ✅ math/gain.json validation
 - ✅ math/integrator.json validation
@@ -161,16 +184,19 @@
 - ✅ io/scope.json validation
 
 For each block:
+
 - Schema validation passes
 - Callback syntax is valid JavaScript
 - Visual properties are correctly formatted
 
 **Directory Structure** (3 tests):
+
 - ✅ Math category directory exists
 - ✅ IO category directory exists
 - ✅ Schema.json in root exists
 
 **Block Consistency Checks** (6 tests):
+
 - ✅ All blocks use current schema version
 - ✅ Math blocks have 'math' category
 - ✅ IO blocks have 'io' category
@@ -180,6 +206,7 @@ For each block:
 - ✅ File names match block names
 
 **Specific Block Functionality** (5 tests):
+
 - ✅ Constant: no inputs, one output
 - ✅ Gain: one input, one output
 - ✅ Integrator: has initial value & state
@@ -187,6 +214,7 @@ For each block:
 - ✅ Scope: no outputs (sink)
 
 **Batch Validation** (2 tests):
+
 - ✅ All math blocks validate
 - ✅ All io blocks validate
 
@@ -195,6 +223,7 @@ For each block:
 ### Validation Logic Coverage
 
 **Schema Validation**: 100%
+
 - All required fields tested
 - All field types tested
 - All pattern validations tested
@@ -202,6 +231,7 @@ For each block:
 - All length limits tested
 
 **Semantic Validation**: 100%
+
 - Port name uniqueness
 - Port reference validation
 - Callback syntax checking
@@ -209,6 +239,7 @@ For each block:
 - prevInput/prevOutput rules
 
 **Edge Cases**: 100%
+
 - Boundary values (min/max lengths)
 - Special characters
 - Unicode handling
@@ -218,6 +249,7 @@ For each block:
 ### Block Definition Coverage
 
 **Port Types Tested**:
+
 - ✅ NUMBER (extensively)
 - ✅ STRING
 - ✅ BOOLEAN
@@ -225,11 +257,13 @@ For each block:
 - ⏭️ MATRIX (schema defined, not tested)
 
 **Visual Properties**:
+
 - ✅ All shapes (rect, circ, tri)
 - ✅ Color validation (hex format)
 - ✅ Icon strings
 
 **Block Categories**:
+
 - ✅ Math category (5 blocks)
 - ✅ IO category (1 block)
 - ⏭️ Other categories (future)
@@ -246,6 +280,7 @@ Time:        3.54s
 ## Key Validations Covered
 
 ### ✅ Schema Compliance
+
 - Required fields presence
 - Field type correctness
 - Pattern matching (names, versions, colors)
@@ -255,6 +290,7 @@ Time:        3.54s
 - Additional property rejection
 
 ### ✅ Semantic Rules
+
 - Port name uniqueness within block
 - Port reference correctness
 - Callback JavaScript syntax
@@ -263,6 +299,7 @@ Time:        3.54s
 - prevOutput references valid outputs
 
 ### ✅ File Integration
+
 - JSON parsing correctness
 - File naming conventions
 - Directory organization
@@ -270,6 +307,7 @@ Time:        3.54s
 - Cross-file consistency
 
 ### ✅ Edge Cases
+
 - Boundary conditions
 - Maximum lengths
 - Special characters
@@ -280,6 +318,7 @@ Time:        3.54s
 ## Files Validated
 
 ### Block Definitions (6 files)
+
 - `block_definitions/math/constant.json` ✅
 - `block_definitions/math/gain.json` ✅
 - `block_definitions/math/integrator.json` ✅
@@ -288,6 +327,7 @@ Time:        3.54s
 - `block_definitions/io/scope.json` ✅
 
 ### Schema Files
+
 - `src/BlockSchema/schema.json` ✅
 - `block_definitions/schema.json` ✅ (copy)
 
@@ -311,6 +351,7 @@ Time:        3.54s
 ## Conclusion
 
 The Block JSON Schema validation system has **comprehensive test coverage** with:
+
 - ✅ 165 total tests (100 new, 65 existing)
 - ✅ 100% pass rate
 - ✅ All validation logic paths tested
@@ -323,6 +364,7 @@ The system is **production-ready** for Phase 1 implementation (file loader and b
 ---
 
 **Test Artifacts**:
+
 - Test files: `packages/common/__tests__/BlockSchema/*.test.ts`
 - Example blocks: `packages/common/block_definitions/**/*.json`
 - Schema: `packages/common/src/BlockSchema/schema.json`

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,10 +16,16 @@ const config = {
     },
     {
       displayName: 'web_app',
-      testMatch: ['<rootDir>/packages/web_app/__tests__/**/*.test.ts', '<rootDir>/packages/web_app/__tests__/**/*.test.tsx'],
+      testMatch: [
+        '<rootDir>/packages/web_app/__tests__/**/*.test.ts',
+        '<rootDir>/packages/web_app/__tests__/**/*.test.tsx'
+      ],
       testEnvironment: 'jsdom',
       setupFilesAfterEnv: ['<rootDir>/packages/web_app/__tests__/setupTests.ts'],
-      collectCoverageFrom: ['<rootDir>/packages/web_app/src/**/*.{ts,tsx}', '!<rootDir>/packages/web_app/src/**/*.d.ts'],
+      collectCoverageFrom: [
+        '<rootDir>/packages/web_app/src/**/*.{ts,tsx}',
+        '!<rootDir>/packages/web_app/src/**/*.d.ts'
+      ],
       coverageDirectory: '<rootDir>/packages/web_app/__tests__/coverage',
       moduleNameMapper: {
         '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
@@ -28,29 +34,30 @@ const config = {
         '^uuid$': require.resolve('uuid')
       },
       transform: {
-        '^.+\\.(ts|tsx)$': ['ts-jest', {
-          tsconfig: {
-            skipLibCheck: true,
-            esModuleInterop: true,
-            allowSyntheticDefaultImports: true,
-            strict: false,
-            isolatedModules: true,
-            jsx: 'react',
-            jsxFactory: 'React.createElement',
-            jsxFragmentFactory: 'React.Fragment',
-            moduleResolution: 'node',
-            resolveJsonModule: true,
-            target: 'es5',
-            module: 'commonjs',
-            lib: ['dom', 'dom.iterable', 'esnext']
-          },
-          isolatedModules: true
-        }],
+        '^.+\\.(ts|tsx)$': [
+          'ts-jest',
+          {
+            tsconfig: {
+              skipLibCheck: true,
+              esModuleInterop: true,
+              allowSyntheticDefaultImports: true,
+              strict: false,
+              isolatedModules: true,
+              jsx: 'react',
+              jsxFactory: 'React.createElement',
+              jsxFragmentFactory: 'React.Fragment',
+              moduleResolution: 'node',
+              resolveJsonModule: true,
+              target: 'es5',
+              module: 'commonjs',
+              lib: ['dom', 'dom.iterable', 'esnext']
+            },
+            isolatedModules: true
+          }
+        ],
         '^.+\\.js$': 'babel-jest'
       },
-      transformIgnorePatterns: [
-        'node_modules/(?!(uuid)/)'
-      ],
+      transformIgnorePatterns: ['node_modules/(?!(uuid)/)'],
       preset: 'ts-jest'
     }
   ]

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-staged": "16.2.6",
     "ncp": "^2.0.0",
     "pre-commit": "^1.0.10",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.8",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.4.5",
     "ts-loader": "^9.5.4",
@@ -72,5 +72,10 @@
     "svgo": "^3.3.2",
     "cross-spawn": "^7.0.6",
     "tmp": "^0.2.3"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,json,css,scss,md,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }

--- a/packages/common/__tests__/BlockLibrary/BlockLibraryManager.test.ts
+++ b/packages/common/__tests__/BlockLibrary/BlockLibraryManager.test.ts
@@ -2,7 +2,11 @@
  * Unit tests for BlockLibraryManager
  */
 
-import { BlockLibraryManager, getDefaultManager, resetDefaultManager } from '../../src/BlockLibrary/BlockLibraryManager';
+import {
+  BlockLibraryManager,
+  getDefaultManager,
+  resetDefaultManager
+} from '../../src/BlockLibrary/BlockLibraryManager';
 import { BlockDefinition } from '../../src/BlockSchema/types';
 import { LibraryEvent, LibraryChangeEvent } from '../../src/BlockLibrary/types';
 
@@ -66,9 +70,7 @@ describe('BlockLibraryManager', () => {
     });
 
     it('should throw when accessing methods before initialization', () => {
-      expect(() => manager.getAllBlocks()).toThrow(
-        'Block library not initialized'
-      );
+      expect(() => manager.getAllBlocks()).toThrow('Block library not initialized');
     });
   });
 
@@ -99,7 +101,7 @@ describe('BlockLibraryManager', () => {
 
     it('should reject invalid block', () => {
       const invalidBlock = {
-        name: 'invalid',
+        name: 'invalid'
         // Missing required fields
       } as unknown as BlockDefinition;
 

--- a/packages/common/__tests__/BlockLibrary/BlockRegistry.test.ts
+++ b/packages/common/__tests__/BlockLibrary/BlockRegistry.test.ts
@@ -52,9 +52,7 @@ describe('BlockRegistry', () => {
       const block = createTestBlock({ name: 'gain' });
       registry.add(block);
 
-      expect(() => registry.add(block)).toThrow(
-        "Block 'gain' already exists in registry"
-      );
+      expect(() => registry.add(block)).toThrow("Block 'gain' already exists in registry");
     });
 
     it('should update an existing block', () => {
@@ -71,9 +69,7 @@ describe('BlockRegistry', () => {
     it('should throw when updating non-existent block', () => {
       const block = createTestBlock({ name: 'gain' });
 
-      expect(() => registry.update('gain', block)).toThrow(
-        "Block 'gain' not found in registry"
-      );
+      expect(() => registry.update('gain', block)).toThrow("Block 'gain' not found in registry");
     });
 
     it('should throw when changing block name during update', () => {
@@ -165,11 +161,7 @@ describe('BlockRegistry', () => {
     it('should search by category', () => {
       const results = registry.search({ category: 'math' });
       expect(results).toHaveLength(3);
-      expect(results.map((b) => b.name).sort()).toEqual([
-        'constant',
-        'gain',
-        'integrator'
-      ]);
+      expect(results.map((b) => b.name).sort()).toEqual(['constant', 'gain', 'integrator']);
     });
 
     it('should search by single tag', () => {
@@ -181,10 +173,7 @@ describe('BlockRegistry', () => {
     it('should search by multiple tags (OR logic)', () => {
       const results = registry.search({ tags: ['diffeq', 'visualization'] });
       expect(results).toHaveLength(2);
-      expect(results.map((b) => b.name).sort()).toEqual([
-        'integrator',
-        'scope'
-      ]);
+      expect(results.map((b) => b.name).sort()).toEqual(['integrator', 'scope']);
     });
 
     it('should combine name and category search', () => {

--- a/packages/common/__tests__/BlockLibrary/BlockWatcher.test.ts
+++ b/packages/common/__tests__/BlockLibrary/BlockWatcher.test.ts
@@ -64,11 +64,7 @@ async function writeBlockFile(dirPath: string, blockName: string, block: BlockDe
 /**
  * Wait for a specific event to be emitted
  */
-function waitForEvent(
-  manager: BlockLibraryManager,
-  eventType: string,
-  timeout: number = 5000
-): Promise<any> {
+function waitForEvent(manager: BlockLibraryManager, eventType: string, timeout: number = 5000): Promise<any> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error(`Timeout waiting for event: ${eventType}`));

--- a/packages/common/__tests__/BlockSchema/async-validation.test.ts
+++ b/packages/common/__tests__/BlockSchema/async-validation.test.ts
@@ -70,7 +70,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should not have path-related warnings
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -105,7 +105,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should have warning about missing icon
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings.length).toBeGreaterThan(0);
       expect(pathWarnings[0].message).toContain('not found');
     });
@@ -125,7 +125,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should not have warning about icon
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -141,7 +141,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should not try to verify non-path icon identifiers
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -160,7 +160,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should find the absolute path
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -181,7 +181,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Should find the icon in the subdirectory
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -198,7 +198,7 @@ describe('BlockValidator - Async Validation', () => {
 
       // Should not crash, and should still validate other aspects
       expect(result).toBeDefined();
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
   });
@@ -219,8 +219,8 @@ describe('BlockValidator - Async Validation', () => {
       // Should have both types of warnings
       expect(result.warnings.length).toBeGreaterThanOrEqual(2);
 
-      const descWarnings = result.warnings.filter(w => w.field === 'description');
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const descWarnings = result.warnings.filter((w) => w.field === 'description');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
 
       expect(descWarnings.length).toBeGreaterThan(0);
       expect(pathWarnings.length).toBeGreaterThan(0);
@@ -245,7 +245,7 @@ describe('BlockValidator - Async Validation', () => {
       expect(result.errors.length).toBeGreaterThan(0);
 
       // Should not have path warnings (didn't get to path validation)
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
   });
@@ -263,7 +263,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = validator.validate(block);
 
       // Sync validation should NOT include path warnings
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings).toHaveLength(0);
     });
 
@@ -279,7 +279,7 @@ describe('BlockValidator - Async Validation', () => {
       const result = await validator.validateAsync(block);
 
       // Async validation SHOULD include path warnings
-      const pathWarnings = result.warnings.filter(w => w.field === 'visual.icon');
+      const pathWarnings = result.warnings.filter((w) => w.field === 'visual.icon');
       expect(pathWarnings.length).toBeGreaterThan(0);
     });
 

--- a/packages/common/__tests__/BlockSchema/block-files-integration.test.ts
+++ b/packages/common/__tests__/BlockSchema/block-files-integration.test.ts
@@ -25,7 +25,7 @@ describe('Block JSON Files Integration', () => {
 
         if (!result.valid) {
           console.error(`Validation errors for ${relativePath}:`);
-          result.errors.forEach(err => {
+          result.errors.forEach((err) => {
             console.error(`  - ${err.field}: ${err.message}`);
           });
         }
@@ -42,15 +42,7 @@ describe('Block JSON Files Integration', () => {
         // Try to create a function from the callback
         expect(() => {
           // eslint-disable-next-line no-new-func
-          new Function(
-            'inputPort',
-            'prevInput',
-            'prevOutput',
-            'initialCondition',
-            't',
-            'dt',
-            block.callbackString
-          );
+          new Function('inputPort', 'prevInput', 'prevOutput', 'initialCondition', 't', 'dt', block.callbackString);
         }).not.toThrow();
       });
 
@@ -106,30 +98,24 @@ describe('Block JSON Files Integration', () => {
 
   describe('Block consistency checks', () => {
     it('all blocks use current schema version', () => {
-      const mathBlocks = fs
-        .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'));
-      const ioBlocks = fs
-        .readdirSync(path.join(blockDefinitionsPath, 'io'))
-        .filter(f => f.endsWith('.json'));
+      const mathBlocks = fs.readdirSync(path.join(blockDefinitionsPath, 'math')).filter((f) => f.endsWith('.json'));
+      const ioBlocks = fs.readdirSync(path.join(blockDefinitionsPath, 'io')).filter((f) => f.endsWith('.json'));
 
       const allBlocks = [
-        ...mathBlocks.map(f => path.join(blockDefinitionsPath, 'math', f)),
-        ...ioBlocks.map(f => path.join(blockDefinitionsPath, 'io', f))
+        ...mathBlocks.map((f) => path.join(blockDefinitionsPath, 'math', f)),
+        ...ioBlocks.map((f) => path.join(blockDefinitionsPath, 'io', f))
       ];
 
-      allBlocks.forEach(blockPath => {
+      allBlocks.forEach((blockPath) => {
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(block.schema_version).toBe(CURRENT_SCHEMA_VERSION);
       });
     });
 
     it('all math blocks have math category', () => {
-      const mathBlocks = fs
-        .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'));
+      const mathBlocks = fs.readdirSync(path.join(blockDefinitionsPath, 'math')).filter((f) => f.endsWith('.json'));
 
-      mathBlocks.forEach(file => {
+      mathBlocks.forEach((file) => {
         const blockPath = path.join(blockDefinitionsPath, 'math', file);
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(block.category).toBe('math');
@@ -137,11 +123,9 @@ describe('Block JSON Files Integration', () => {
     });
 
     it('all io blocks have io category', () => {
-      const ioBlocks = fs
-        .readdirSync(path.join(blockDefinitionsPath, 'io'))
-        .filter(f => f.endsWith('.json'));
+      const ioBlocks = fs.readdirSync(path.join(blockDefinitionsPath, 'io')).filter((f) => f.endsWith('.json'));
 
-      ioBlocks.forEach(file => {
+      ioBlocks.forEach((file) => {
         const blockPath = path.join(blockDefinitionsPath, 'io', file);
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(block.category).toBe('io');
@@ -151,15 +135,15 @@ describe('Block JSON Files Integration', () => {
     it('all blocks have descriptions', () => {
       const mathBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'math', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'math', f));
 
       const ioBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'io'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'io', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'io', f));
 
-      [...mathBlocks, ...ioBlocks].forEach(blockPath => {
+      [...mathBlocks, ...ioBlocks].forEach((blockPath) => {
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(block.description).toBeTruthy();
         expect(block.description.length).toBeGreaterThan(0);
@@ -169,15 +153,15 @@ describe('Block JSON Files Integration', () => {
     it('all blocks have tags', () => {
       const mathBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'math', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'math', f));
 
       const ioBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'io'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'io', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'io', f));
 
-      [...mathBlocks, ...ioBlocks].forEach(blockPath => {
+      [...mathBlocks, ...ioBlocks].forEach((blockPath) => {
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(Array.isArray(block.tags)).toBe(true);
         expect(block.tags.length).toBeGreaterThan(0);
@@ -187,15 +171,15 @@ describe('Block JSON Files Integration', () => {
     it('all blocks have visual properties', () => {
       const mathBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'math', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'math', f));
 
       const ioBlocks = fs
         .readdirSync(path.join(blockDefinitionsPath, 'io'))
-        .filter(f => f.endsWith('.json'))
-        .map(f => path.join(blockDefinitionsPath, 'io', f));
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(blockDefinitionsPath, 'io', f));
 
-      [...mathBlocks, ...ioBlocks].forEach(blockPath => {
+      [...mathBlocks, ...ioBlocks].forEach((blockPath) => {
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         expect(block.visual).toBeDefined();
         expect(block.visual.color).toBeDefined();
@@ -205,11 +189,9 @@ describe('Block JSON Files Integration', () => {
     });
 
     it('file names match block names', () => {
-      const mathBlocks = fs
-        .readdirSync(path.join(blockDefinitionsPath, 'math'))
-        .filter(f => f.endsWith('.json'));
+      const mathBlocks = fs.readdirSync(path.join(blockDefinitionsPath, 'math')).filter((f) => f.endsWith('.json'));
 
-      mathBlocks.forEach(file => {
+      mathBlocks.forEach((file) => {
         const blockPath = path.join(blockDefinitionsPath, 'math', file);
         const block = JSON.parse(fs.readFileSync(blockPath, 'utf8'));
         const expectedFileName = `${block.name}.json`;
@@ -269,23 +251,23 @@ describe('Block JSON Files Integration', () => {
   describe('Batch validation', () => {
     it('validates all blocks in math directory', () => {
       const mathDir = path.join(blockDefinitionsPath, 'math');
-      const files = fs.readdirSync(mathDir).filter(f => f.endsWith('.json'));
+      const files = fs.readdirSync(mathDir).filter((f) => f.endsWith('.json'));
 
       expect(files.length).toBeGreaterThan(0);
 
-      const results = files.map(file => {
+      const results = files.map((file) => {
         const filePath = path.join(mathDir, file);
         const block = JSON.parse(fs.readFileSync(filePath, 'utf8'));
         return { file, result: validateBlock(block) };
       });
 
-      const invalid = results.filter(r => !r.result.valid);
+      const invalid = results.filter((r) => !r.result.valid);
 
       if (invalid.length > 0) {
         console.error('Invalid blocks found:');
         invalid.forEach(({ file, result }) => {
           console.error(`\n${file}:`);
-          result.errors.forEach(err => console.error(`  - ${err.message}`));
+          result.errors.forEach((err) => console.error(`  - ${err.message}`));
         });
       }
 
@@ -294,17 +276,17 @@ describe('Block JSON Files Integration', () => {
 
     it('validates all blocks in io directory', () => {
       const ioDir = path.join(blockDefinitionsPath, 'io');
-      const files = fs.readdirSync(ioDir).filter(f => f.endsWith('.json'));
+      const files = fs.readdirSync(ioDir).filter((f) => f.endsWith('.json'));
 
       expect(files.length).toBeGreaterThan(0);
 
-      const results = files.map(file => {
+      const results = files.map((file) => {
         const filePath = path.join(ioDir, file);
         const block = JSON.parse(fs.readFileSync(filePath, 'utf8'));
         return { file, result: validateBlock(block) };
       });
 
-      const invalid = results.filter(r => !r.result.valid);
+      const invalid = results.filter((r) => !r.result.valid);
       expect(invalid.length).toBe(0);
     });
   });

--- a/packages/common/__tests__/BlockSchema/callback-validation.test.ts
+++ b/packages/common/__tests__/BlockSchema/callback-validation.test.ts
@@ -85,7 +85,7 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.message.includes('no initialValue'))).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('no initialValue'))).toBe(true);
     });
   });
 
@@ -208,9 +208,7 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(
-        result.errors.some(e => e.message.includes('unknown input port') && e.message.includes('z'))
-      ).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('unknown input port') && e.message.includes('z'))).toBe(true);
     });
 
     it('detects reference to non-existent output in prevOutput', () => {
@@ -225,9 +223,9 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(
-        result.errors.some(e => e.message.includes('unknown output port') && e.message.includes('z'))
-      ).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('unknown output port') && e.message.includes('z'))).toBe(
+        true
+      );
     });
 
     it('detects multiple undefined references', () => {
@@ -242,7 +240,7 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.filter(e => e.message.includes('unknown input port')).length).toBe(3);
+      expect(result.errors.filter((e) => e.message.includes('unknown input port')).length).toBe(3);
     });
 
     it('detects syntax error: unclosed string', () => {
@@ -257,7 +255,7 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.message.includes('Invalid JavaScript syntax'))).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('Invalid JavaScript syntax'))).toBe(true);
     });
 
     it('detects syntax error: invalid operator', () => {
@@ -318,8 +316,7 @@ describe('Callback String Validation', () => {
           { name: 'setPoint', type: 'NUMBER' }
         ],
         outputPorts: [{ name: 'OutputValue', type: 'NUMBER' }],
-        callbackString:
-          'return [inputPort[InputValue] - inputPort[setPoint] + prevOutput[OutputValue]]'
+        callbackString: 'return [inputPort[InputValue] - inputPort[setPoint] + prevOutput[OutputValue]]'
       };
 
       const result = validator.validate(block);
@@ -338,7 +335,7 @@ describe('Callback String Validation', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.message.includes('unknown input port'))).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('unknown input port'))).toBe(true);
     });
   });
 

--- a/packages/common/__tests__/BlockSchema/migrator.test.ts
+++ b/packages/common/__tests__/BlockSchema/migrator.test.ts
@@ -3,12 +3,7 @@
  * Tests version migration and compatibility checking
  */
 
-import {
-  BlockSchemaMigrator,
-  getMigrator,
-  migrateBlock,
-  canMigrateVersion
-} from '../../src/BlockSchema/migrator';
+import { BlockSchemaMigrator, getMigrator, migrateBlock, canMigrateVersion } from '../../src/BlockSchema/migrator';
 import { BlockDefinition, CURRENT_SCHEMA_VERSION } from '../../src/BlockSchema/types';
 
 describe('BlockSchemaMigrator', () => {
@@ -307,7 +302,7 @@ describe('BlockSchemaMigrator', () => {
       const result = migrator.migrate(block);
 
       if (result.migrated) {
-        result.warnings.forEach(warning => {
+        result.warnings.forEach((warning) => {
           expect(warning).toBeTruthy();
           expect(typeof warning).toBe('string');
           expect(warning.length).toBeGreaterThan(0);

--- a/packages/common/__tests__/BlockSchema/schema-edge-cases.test.ts
+++ b/packages/common/__tests__/BlockSchema/schema-edge-cases.test.ts
@@ -332,7 +332,7 @@ describe('BlockSchema Edge Cases', () => {
 
       const result = validateBlock(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.message.includes('Invalid JavaScript syntax'))).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('Invalid JavaScript syntax'))).toBe(true);
     });
 
     it('detects syntax error: invalid JavaScript', () => {
@@ -449,7 +449,7 @@ describe('BlockSchema Edge Cases', () => {
 
       const result = validateBlock(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.message.includes('unknown input port'))).toBe(true);
+      expect(result.errors.some((e) => e.message.includes('unknown input port'))).toBe(true);
     });
 
     it('accepts dot notation for port access', () => {
@@ -530,7 +530,7 @@ describe('BlockSchema Edge Cases', () => {
     it('accepts all valid hex colors', () => {
       const colors = ['#000000', '#FFFFFF', '#FF5722', '#4CAF50', '#2196F3'];
 
-      colors.forEach(color => {
+      colors.forEach((color) => {
         const block: BlockDefinition = {
           schema_version: CURRENT_SCHEMA_VERSION,
           name: 'test',
@@ -549,7 +549,7 @@ describe('BlockSchema Edge Cases', () => {
     it('rejects invalid hex color formats', () => {
       const invalidColors = ['#FFF', '#GGGGGG', 'red', 'rgb(255,0,0)', '#12345'];
 
-      invalidColors.forEach(color => {
+      invalidColors.forEach((color) => {
         const block = {
           schema_version: CURRENT_SCHEMA_VERSION,
           name: 'test',

--- a/packages/common/__tests__/BlockSchema/validator.test.ts
+++ b/packages/common/__tests__/BlockSchema/validator.test.ts
@@ -258,9 +258,7 @@ describe('BlockValidator', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(result.errors.some((e: ValidationError) => e.message.includes('Invalid JavaScript syntax'))).toBe(
-        true
-      );
+      expect(result.errors.some((e: ValidationError) => e.message.includes('Invalid JavaScript syntax'))).toBe(true);
     });
 
     it('detects type mismatch in initial value', () => {
@@ -275,9 +273,9 @@ describe('BlockValidator', () => {
 
       const result = validator.validate(block);
       expect(result.valid).toBe(false);
-      expect(
-        result.errors.some((e: ValidationError) => e.message.includes('Initial value for NUMBER port'))
-      ).toBe(true);
+      expect(result.errors.some((e: ValidationError) => e.message.includes('Initial value for NUMBER port'))).toBe(
+        true
+      );
     });
   });
 

--- a/packages/common/__tests__/jest.config.ts
+++ b/packages/common/__tests__/jest.config.ts
@@ -6,12 +6,5 @@ module.exports = {
   collectCoverageFrom: ['../src/**/*.ts'],
   coverageReporters: ['json', 'html'],
   coverageDirectory: './coverage',
-  coveragePathIgnorePatterns: [
-    '/node_modules/',
-    '/dist/',
-    'index.ts',
-    'Types.ts',
-    'types.ts',
-    '/coverage/'
-  ]
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', 'index.ts', 'Types.ts', 'types.ts', '/coverage/']
 };

--- a/packages/common/block_definitions/schema.json
+++ b/packages/common/block_definitions/schema.json
@@ -4,14 +4,7 @@
   "title": "CompX Block Definition",
   "description": "Schema for defining computational blocks in CompX",
   "type": "object",
-  "required": [
-    "schema_version",
-    "name",
-    "version",
-    "inputPorts",
-    "outputPorts",
-    "callbackString"
-  ],
+  "required": ["schema_version", "name", "version", "inputPorts", "outputPorts", "callbackString"],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -127,11 +120,7 @@
         },
         "initialValue": {
           "description": "Initial value for the port (enables prevInput access)",
-          "oneOf": [
-            { "type": "number" },
-            { "type": "string" },
-            { "type": "boolean" }
-          ]
+          "oneOf": [{ "type": "number" }, { "type": "string" }, { "type": "boolean" }]
         }
       },
       "additionalProperties": false

--- a/packages/common/src/BlockLibrary/BlockLibraryManager.ts
+++ b/packages/common/src/BlockLibrary/BlockLibraryManager.ts
@@ -7,13 +7,7 @@ import { EventEmitter } from 'events';
 import { BlockDefinition, ValidationResult } from '../BlockSchema/types';
 import { validateBlock } from '../BlockSchema/validator';
 import { BlockRegistry } from './BlockRegistry';
-import {
-  BlockSearchQuery,
-  LibraryEvent,
-  LibraryEventCallback,
-  LibraryEventType,
-  LibraryStats
-} from './types';
+import { BlockSearchQuery, LibraryEvent, LibraryEventCallback, LibraryEventType, LibraryStats } from './types';
 
 /**
  * Configuration options for BlockLibraryManager
@@ -367,9 +361,7 @@ let defaultManager: BlockLibraryManager | null = null;
  * @param options - Configuration options (only used on first call)
  * @returns The default manager instance
  */
-export function getDefaultManager(
-  options?: BlockLibraryManagerOptions
-): BlockLibraryManager {
+export function getDefaultManager(options?: BlockLibraryManagerOptions): BlockLibraryManager {
   if (!defaultManager) {
     defaultManager = new BlockLibraryManager(options);
   }

--- a/packages/common/src/BlockLibrary/BlockRegistry.ts
+++ b/packages/common/src/BlockLibrary/BlockRegistry.ts
@@ -124,9 +124,7 @@ export class BlockRegistry {
     // Filter by name (partial, case-insensitive match)
     if (query.name) {
       const nameLower = query.name.toLowerCase();
-      results = new Set(
-        Array.from(results).filter((name) => name.toLowerCase().includes(nameLower))
-      );
+      results = new Set(Array.from(results).filter((name) => name.toLowerCase().includes(nameLower)));
     }
 
     // Filter by category (exact match)

--- a/packages/common/src/BlockLibrary/BlockWatcher.ts
+++ b/packages/common/src/BlockLibrary/BlockWatcher.ts
@@ -331,7 +331,9 @@ export class BlockWatcher {
       this.logError(`Failed to load block from ${filePath}:`, error);
       this.manager.emit('library-error', {
         type: 'library-error',
-        message: `Failed to load block from ${path.basename(filePath)}: ${error instanceof Error ? error.message : String(error)}`,
+        message: `Failed to load block from ${path.basename(filePath)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
         blockFile: filePath,
         timestamp: Date.now(),
         details: error
@@ -424,11 +426,7 @@ export class BlockWatcher {
 /**
  * Helper function to create standard watched directory configurations
  */
-export function createWatchedDirectory(
-  dirPath: string,
-  readOnly: boolean,
-  description: string
-): WatchedDirectory {
+export function createWatchedDirectory(dirPath: string, readOnly: boolean, description: string): WatchedDirectory {
   return {
     path: path.resolve(dirPath),
     readOnly,
@@ -442,10 +440,7 @@ export function createWatchedDirectory(
  * @param userDataDir - Path to user data directory
  * @returns Array of watched directories
  */
-export function createStandardWatchDirectories(
-  coreBlocksDir: string,
-  userDataDir: string
-): WatchedDirectory[] {
+export function createStandardWatchDirectories(coreBlocksDir: string, userDataDir: string): WatchedDirectory[] {
   return [
     createWatchedDirectory(coreBlocksDir, true, 'Core blocks (read-only)'),
     createWatchedDirectory(path.join(userDataDir, 'custom_blocks'), false, 'User-created blocks'),

--- a/packages/common/src/BlockLibrary/index.ts
+++ b/packages/common/src/BlockLibrary/index.ts
@@ -28,7 +28,12 @@
  * ```
  */
 
-export { BlockLibraryManager, BlockLibraryManagerOptions, getDefaultManager, resetDefaultManager } from './BlockLibraryManager';
+export {
+  BlockLibraryManager,
+  BlockLibraryManagerOptions,
+  getDefaultManager,
+  resetDefaultManager
+} from './BlockLibraryManager';
 export { BlockRegistry } from './BlockRegistry';
 export {
   BlockWatcher,

--- a/packages/common/src/BlockLibrary/types.ts
+++ b/packages/common/src/BlockLibrary/types.ts
@@ -21,7 +21,12 @@ export interface BlockSearchQuery {
 /**
  * Types of events emitted by the Block Library Manager
  */
-export type LibraryEventType = 'block-added' | 'block-updated' | 'block-removed' | 'library-initialized' | 'library-error';
+export type LibraryEventType =
+  | 'block-added'
+  | 'block-updated'
+  | 'block-removed'
+  | 'library-initialized'
+  | 'library-error';
 
 /**
  * Event data for library changes

--- a/packages/common/src/BlockSchema/schema.json
+++ b/packages/common/src/BlockSchema/schema.json
@@ -4,14 +4,7 @@
   "title": "CompX Block Definition",
   "description": "Schema for defining computational blocks in CompX",
   "type": "object",
-  "required": [
-    "schema_version",
-    "name",
-    "version",
-    "inputPorts",
-    "outputPorts",
-    "callbackString"
-  ],
+  "required": ["schema_version", "name", "version", "inputPorts", "outputPorts", "callbackString"],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -127,11 +120,7 @@
         },
         "initialValue": {
           "description": "Initial value for the port (enables prevInput access)",
-          "oneOf": [
-            { "type": "number" },
-            { "type": "string" },
-            { "type": "boolean" }
-          ]
+          "oneOf": [{ "type": "number" }, { "type": "string" }, { "type": "boolean" }]
         }
       },
       "additionalProperties": false

--- a/packages/common/src/BlockSchema/types.js
+++ b/packages/common/src/BlockSchema/types.js
@@ -1,9 +1,9 @@
-"use strict";
+'use strict';
 /**
  * TypeScript types generated from Block Definition JSON Schema
  * These types represent the structure of block definitions in CompX
  */
-Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, '__esModule', { value: true });
 exports.PORT_TYPE_DEFAULTS = exports.CURRENT_SCHEMA_VERSION = exports.BLOCK_DEFAULTS = void 0;
 exports.isPortDefinition = isPortDefinition;
 exports.isBlockDefinition = isBlockDefinition;
@@ -11,39 +11,41 @@ exports.isBlockDefinition = isBlockDefinition;
  * Type guard to check if an object is a valid PortDefinition
  */
 function isPortDefinition(obj) {
-    if (typeof obj !== 'object' || obj === null)
-        return false;
-    const port = obj;
-    return (typeof port.name === 'string' &&
-        typeof port.type === 'string' &&
-        ['NUMBER', 'STRING', 'VECTOR', 'MATRIX', 'BOOLEAN'].includes(port.type));
+  if (typeof obj !== 'object' || obj === null) return false;
+  const port = obj;
+  return (
+    typeof port.name === 'string' &&
+    typeof port.type === 'string' &&
+    ['NUMBER', 'STRING', 'VECTOR', 'MATRIX', 'BOOLEAN'].includes(port.type)
+  );
 }
 /**
  * Type guard to check if an object is a valid BlockDefinition
  */
 function isBlockDefinition(obj) {
-    if (typeof obj !== 'object' || obj === null)
-        return false;
-    const block = obj;
-    return (typeof block.schema_version === 'string' &&
-        typeof block.name === 'string' &&
-        typeof block.version === 'string' &&
-        Array.isArray(block.inputPorts) &&
-        Array.isArray(block.outputPorts) &&
-        typeof block.callbackString === 'string');
+  if (typeof obj !== 'object' || obj === null) return false;
+  const block = obj;
+  return (
+    typeof block.schema_version === 'string' &&
+    typeof block.name === 'string' &&
+    typeof block.version === 'string' &&
+    Array.isArray(block.inputPorts) &&
+    Array.isArray(block.outputPorts) &&
+    typeof block.callbackString === 'string'
+  );
 }
 /**
  * Default values for optional fields
  */
 exports.BLOCK_DEFAULTS = {
-    description: '',
-    category: 'misc',
-    tags: [],
-    visual: {
-        color: '#9E9E9E',
-        icon: '',
-        shape: 'rect'
-    }
+  description: '',
+  category: 'misc',
+  tags: [],
+  visual: {
+    color: '#9E9E9E',
+    icon: '',
+    shape: 'rect'
+  }
 };
 /**
  * Current schema version
@@ -53,10 +55,10 @@ exports.CURRENT_SCHEMA_VERSION = '1.0.0';
  * Port type initial value defaults
  */
 exports.PORT_TYPE_DEFAULTS = {
-    NUMBER: 0,
-    STRING: '',
-    VECTOR: 0, // Will need proper Vector2D type later
-    MATRIX: 0, // Will need proper Matrix2D type later
-    BOOLEAN: false
+  NUMBER: 0,
+  STRING: '',
+  VECTOR: 0, // Will need proper Vector2D type later
+  MATRIX: 0, // Will need proper Matrix2D type later
+  BOOLEAN: false
 };
 //# sourceMappingURL=types.js.map

--- a/packages/common/src/BlockSchema/validator.ts
+++ b/packages/common/src/BlockSchema/validator.ts
@@ -102,7 +102,7 @@ export class BlockValidator {
           message: `Block automatically migrated from ${migrationResult.originalVersion} to ${migrationResult.targetVersion}`,
           severity: 'warning'
         });
-        migrationResult.warnings.forEach(w => {
+        migrationResult.warnings.forEach((w) => {
           warnings.push({
             field: 'migration',
             message: w,
@@ -110,7 +110,7 @@ export class BlockValidator {
           });
         });
       } else if (migrationResult.warnings.length > 0) {
-        migrationResult.warnings.forEach(w => {
+        migrationResult.warnings.forEach((w) => {
           warnings.push({
             field: 'schema_version',
             message: w,
@@ -181,9 +181,7 @@ export class BlockValidator {
   /**
    * Perform semantic validation beyond JSON Schema
    */
-  private validateSemantics(
-    block: BlockDefinition
-  ): Pick<ValidationResult, 'errors' | 'warnings'> {
+  private validateSemantics(block: BlockDefinition): Pick<ValidationResult, 'errors' | 'warnings'> {
     const errors: ValidationError[] = [];
     const warnings: ValidationError[] = [];
 
@@ -197,10 +195,7 @@ export class BlockValidator {
     }
 
     // Check port name uniqueness within block
-    const allPortNames = [
-      ...block.inputPorts.map((p) => p.name),
-      ...block.outputPorts.map((p) => p.name)
-    ];
+    const allPortNames = [...block.inputPorts.map((p) => p.name), ...block.outputPorts.map((p) => p.name)];
     const duplicates = this.findDuplicates(allPortNames);
     if (duplicates.length > 0) {
       errors.push({
@@ -211,11 +206,7 @@ export class BlockValidator {
     }
 
     // Validate callback string syntax
-    const callbackErrors = this.validateCallbackString(
-      block.callbackString,
-      block.inputPorts,
-      block.outputPorts
-    );
+    const callbackErrors = this.validateCallbackString(block.callbackString, block.inputPorts, block.outputPorts);
     errors.push(...callbackErrors);
 
     // Validate initial values match port types
@@ -268,15 +259,7 @@ export class BlockValidator {
     try {
       // Try to create a function (this doesn't execute it)
       // eslint-disable-next-line no-new-func
-      new Function(
-        'inputPort',
-        'prevInput',
-        'prevOutput',
-        'initialCondition',
-        't',
-        'dt',
-        callbackString
-      );
+      new Function('inputPort', 'prevInput', 'prevOutput', 'initialCondition', 't', 'dt', callbackString);
     } catch (e) {
       errors.push({
         field: 'callbackString',
@@ -296,7 +279,9 @@ export class BlockValidator {
       if (!inputPortNames.includes(ref)) {
         errors.push({
           field: 'callbackString',
-          message: `Reference to unknown input port 'inputPort[${ref}]'. Available inputs: ${inputPortNames.join(', ') || 'none'}`,
+          message: `Reference to unknown input port 'inputPort[${ref}]'. Available inputs: ${
+            inputPortNames.join(', ') || 'none'
+          }`,
           severity: 'error'
         });
       }
@@ -308,7 +293,9 @@ export class BlockValidator {
       if (!outputPortNames.includes(ref)) {
         errors.push({
           field: 'callbackString',
-          message: `Reference to unknown output port 'prevOutput[${ref}]'. Available outputs: ${outputPortNames.join(', ') || 'none'}`,
+          message: `Reference to unknown output port 'prevOutput[${ref}]'. Available outputs: ${
+            outputPortNames.join(', ') || 'none'
+          }`,
           severity: 'error'
         });
       }
@@ -321,7 +308,9 @@ export class BlockValidator {
       if (!port) {
         errors.push({
           field: 'callbackString',
-          message: `Reference to unknown input port 'prevInput[${ref}]'. Available inputs: ${inputPortNames.join(', ') || 'none'}`,
+          message: `Reference to unknown input port 'prevInput[${ref}]'. Available inputs: ${
+            inputPortNames.join(', ') || 'none'
+          }`,
           severity: 'error'
         });
       } else if (port.initialValue === undefined) {
@@ -433,9 +422,7 @@ export class BlockValidator {
       }
 
       // Resolve path relative to base directory
-      const resolvedPath = path.isAbsolute(iconPath)
-        ? iconPath
-        : path.resolve(this.options.baseDir, iconPath);
+      const resolvedPath = path.isAbsolute(iconPath) ? iconPath : path.resolve(this.options.baseDir, iconPath);
 
       try {
         await fs.access(resolvedPath);

--- a/packages/common/src/Graph/Edge.ts
+++ b/packages/common/src/Graph/Edge.ts
@@ -3,7 +3,7 @@ import { PortTypes } from './Port';
 import GraphObject from './GraphObjectBase';
 
 const EdgeTypesStringList = ['TREE', 'BACK', 'FORWARD', 'CROSS'] as const;
-export type EdgeTypes = typeof EdgeTypesStringList[number];
+export type EdgeTypes = (typeof EdgeTypesStringList)[number];
 
 export class Edge<U extends keyof PortTypes> implements EdgeStorageType<U>, GraphObject<Edge<U>> {
   public readonly id: string;

--- a/packages/common/src/Graph/Port.ts
+++ b/packages/common/src/Graph/Port.ts
@@ -4,7 +4,7 @@ import { PortStorageType, PortStorageWithIDType } from '../Network/GraphItemStor
 import GraphObject from './GraphObjectBase';
 
 export const PortTypesStringList = ['STRING', 'NUMBER'] as const;
-type PortInterfaceType = { [K in typeof PortTypesStringList[number]]: any };
+type PortInterfaceType = { [K in (typeof PortTypesStringList)[number]]: any };
 export interface PortTypes extends PortInterfaceType {
   STRING: string;
   NUMBER: number;
@@ -14,7 +14,7 @@ export const PortTypeInitializers: PortTypes = {
   NUMBER: 0
 };
 
-export type StringListUnionType = typeof PortTypesStringList[number];
+export type StringListUnionType = (typeof PortTypesStringList)[number];
 export type PortStringListType = StringListUnionType[];
 export type MapStringsToPortsType<T extends PortStringListType> = {
   [K in keyof T]: T[K] extends PortStringListType[number] ? Port<T[K]> : never;

--- a/packages/common/src/Helpers/ErrorHandling.ts
+++ b/packages/common/src/Helpers/ErrorHandling.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { CompXErrorJson, ErrorTypeStrings } from '../Network/ErrorHandling';
 
 export class CompXError extends Error {
-  private errorType: typeof ErrorTypeStrings[number];
+  private errorType: (typeof ErrorTypeStrings)[number];
   private compxStack?: CompXError;
 
   // Create the error from a json
@@ -14,7 +14,7 @@ export class CompXError extends Error {
   }
 
   // basic constructor
-  constructor(errorType: typeof ErrorTypeStrings[number], errorName: string, message: string) {
+  constructor(errorType: (typeof ErrorTypeStrings)[number], errorName: string, message: string) {
     super(message);
     Object.setPrototypeOf(this, CompXError.prototype);
 

--- a/packages/common/src/Network/ErrorHandling.ts
+++ b/packages/common/src/Network/ErrorHandling.ts
@@ -1,7 +1,7 @@
 export const ErrorTypeStrings = ['info', 'warning', 'error'] as const;
 
 export type CompXErrorJson = {
-  errorType: typeof ErrorTypeStrings[number];
+  errorType: (typeof ErrorTypeStrings)[number];
   name: string;
   message: string;
   stack?: CompXErrorJson;
@@ -15,7 +15,7 @@ export function isCompXErrorJson(d: any): d is CompXErrorJson {
 
   if (
     typeof d['errorType'] !== 'string' ||
-    !ErrorTypeStrings.includes(d['errorType'] as typeof ErrorTypeStrings[number])
+    !ErrorTypeStrings.includes(d['errorType'] as (typeof ErrorTypeStrings)[number])
   )
     return false;
   if (typeof d['name'] !== 'string') return false;

--- a/packages/common/src/Network/GraphItemStorage/EdgeStorage.ts
+++ b/packages/common/src/Network/GraphItemStorage/EdgeStorage.ts
@@ -28,7 +28,7 @@ export function isEdgeStorageType<U extends keyof PortTypes>(obj: any): obj is E
   if (typeof obj['id'] !== 'string') return false;
   if (
     typeof obj['type'] !== 'string' ||
-    !PortTypesStringList.includes(obj['type'] as typeof PortTypesStringList[number])
+    !PortTypesStringList.includes(obj['type'] as (typeof PortTypesStringList)[number])
   )
     return false;
 

--- a/packages/common/src/Network/GraphItemStorage/PortStorage.ts
+++ b/packages/common/src/Network/GraphItemStorage/PortStorage.ts
@@ -16,12 +16,12 @@ export function isPortStorageType<U extends keyof PortTypes>(obj: any): obj is P
   if (typeof obj['name'] !== 'string') return false;
   if (
     typeof obj['type'] !== 'string' ||
-    !PortTypesStringList.includes(obj['type'] as typeof PortTypesStringList[number])
+    !PortTypesStringList.includes(obj['type'] as (typeof PortTypesStringList)[number])
   )
     return false;
 
   if ('initialValue' in obj && obj['initialValue'] !== undefined) {
-    switch (obj['type'] as typeof PortTypesStringList[number]) {
+    switch (obj['type'] as (typeof PortTypesStringList)[number]) {
       case 'STRING': {
         if (typeof obj['initialValue'] !== 'string') return false;
         break;

--- a/packages/electron_app/src/ipc/blockServiceHandlers.ts
+++ b/packages/electron_app/src/ipc/blockServiceHandlers.ts
@@ -39,20 +39,17 @@ export async function setupBlockServiceHandlers(): Promise<void> {
   /**
    * Get all available blocks
    */
-  ipcMain.handle(
-    IPC_CHANNELS.GET_ALL,
-    async (event: IpcMainInvokeEvent): Promise<BlockDefinition[]> => {
-      try {
-        console.log('IPC: GET_ALL - Fetching all blocks');
-        const blocks = await blockManager.getAvailableBlocks();
-        console.log(`IPC: GET_ALL - Returning ${blocks.length} blocks`);
-        return blocks;
-      } catch (error) {
-        console.error('IPC: GET_ALL - Error:', error);
-        throw error;
-      }
+  ipcMain.handle(IPC_CHANNELS.GET_ALL, async (event: IpcMainInvokeEvent): Promise<BlockDefinition[]> => {
+    try {
+      console.log('IPC: GET_ALL - Fetching all blocks');
+      const blocks = await blockManager.getAvailableBlocks();
+      console.log(`IPC: GET_ALL - Returning ${blocks.length} blocks`);
+      return blocks;
+    } catch (error) {
+      console.error('IPC: GET_ALL - Error:', error);
+      throw error;
     }
-  );
+  });
 
   /**
    * Get a specific block by name
@@ -81,66 +78,57 @@ export async function setupBlockServiceHandlers(): Promise<void> {
   /**
    * Search blocks by query string
    */
-  ipcMain.handle(
-    IPC_CHANNELS.SEARCH,
-    async (event: IpcMainInvokeEvent, query: string): Promise<BlockDefinition[]> => {
-      try {
-        console.log(`IPC: SEARCH - Query: "${query}"`);
-        const results = await blockManager.searchBlocks(query);
-        console.log(`IPC: SEARCH - Found ${results.length} results`);
-        return results;
-      } catch (error) {
-        console.error(`IPC: SEARCH - Error searching for "${query}":`, error);
-        throw error;
-      }
+  ipcMain.handle(IPC_CHANNELS.SEARCH, async (event: IpcMainInvokeEvent, query: string): Promise<BlockDefinition[]> => {
+    try {
+      console.log(`IPC: SEARCH - Query: "${query}"`);
+      const results = await blockManager.searchBlocks(query);
+      console.log(`IPC: SEARCH - Found ${results.length} results`);
+      return results;
+    } catch (error) {
+      console.error(`IPC: SEARCH - Error searching for "${query}":`, error);
+      throw error;
     }
-  );
+  });
 
   /**
    * Install a block pack
    */
-  ipcMain.handle(
-    IPC_CHANNELS.INSTALL_PACK,
-    async (event: IpcMainInvokeEvent, source: string): Promise<void> => {
-      try {
-        console.log(`IPC: INSTALL_PACK - Installing from: ${source}`);
-        await blockManager.installBlockPack(source);
-        console.log(`IPC: INSTALL_PACK - Installation complete`);
+  ipcMain.handle(IPC_CHANNELS.INSTALL_PACK, async (event: IpcMainInvokeEvent, source: string): Promise<void> => {
+    try {
+      console.log(`IPC: INSTALL_PACK - Installing from: ${source}`);
+      await blockManager.installBlockPack(source);
+      console.log(`IPC: INSTALL_PACK - Installation complete`);
 
-        // TODO: Emit library changed event to all windows
-        // event.sender.send(IPC_CHANNELS.CHANGED, {
-        //   type: 'pack-installed',
-        //   source
-        // });
-      } catch (error) {
-        console.error(`IPC: INSTALL_PACK - Error installing from ${source}:`, error);
-        throw error;
-      }
+      // TODO: Emit library changed event to all windows
+      // event.sender.send(IPC_CHANNELS.CHANGED, {
+      //   type: 'pack-installed',
+      //   source
+      // });
+    } catch (error) {
+      console.error(`IPC: INSTALL_PACK - Error installing from ${source}:`, error);
+      throw error;
     }
-  );
+  });
 
   /**
    * Uninstall a block pack
    */
-  ipcMain.handle(
-    IPC_CHANNELS.UNINSTALL_PACK,
-    async (event: IpcMainInvokeEvent, packName: string): Promise<void> => {
-      try {
-        console.log(`IPC: UNINSTALL_PACK - Uninstalling: ${packName}`);
-        await blockManager.uninstallBlockPack(packName);
-        console.log(`IPC: UNINSTALL_PACK - Uninstallation complete`);
+  ipcMain.handle(IPC_CHANNELS.UNINSTALL_PACK, async (event: IpcMainInvokeEvent, packName: string): Promise<void> => {
+    try {
+      console.log(`IPC: UNINSTALL_PACK - Uninstalling: ${packName}`);
+      await blockManager.uninstallBlockPack(packName);
+      console.log(`IPC: UNINSTALL_PACK - Uninstallation complete`);
 
-        // TODO: Emit library changed event to all windows
-        // event.sender.send(IPC_CHANNELS.CHANGED, {
-        //   type: 'pack-uninstalled',
-        //   packName
-        // });
-      } catch (error) {
-        console.error(`IPC: UNINSTALL_PACK - Error uninstalling ${packName}:`, error);
-        throw error;
-      }
+      // TODO: Emit library changed event to all windows
+      // event.sender.send(IPC_CHANNELS.CHANGED, {
+      //   type: 'pack-uninstalled',
+      //   packName
+      // });
+    } catch (error) {
+      console.error(`IPC: UNINSTALL_PACK - Error uninstalling ${packName}:`, error);
+      throw error;
     }
-  );
+  });
 
   console.log(`Block service IPC handlers registered (${blockManager.getBlockCount()} blocks loaded)`);
 }

--- a/packages/electron_app/src/services/BlockManager.ts
+++ b/packages/electron_app/src/services/BlockManager.ts
@@ -24,11 +24,7 @@ export enum BlockManagerErrorCode {
  * Block manager error
  */
 export class BlockManagerError extends Error {
-  constructor(
-    message: string,
-    public code: BlockManagerErrorCode,
-    public cause?: unknown
-  ) {
+  constructor(message: string, public code: BlockManagerErrorCode, public cause?: unknown) {
     super(message);
     this.name = 'BlockManagerError';
   }
@@ -89,7 +85,7 @@ export class BlockManager {
   private async loadBlocksFromDisk(): Promise<void> {
     try {
       const files = fs.readdirSync(this.blockStoragePath);
-      const jsonFiles = files.filter(f => f.endsWith('.json'));
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
 
       console.log(`Found ${jsonFiles.length} JSON files in block storage`);
 
@@ -193,10 +189,7 @@ export class BlockManager {
   async installBlockPack(source: string): Promise<void> {
     // TODO: Implement block pack installation
     // This will be implemented in a future phase
-    throw new BlockManagerError(
-      'Block pack installation not yet implemented',
-      BlockManagerErrorCode.STORAGE_ERROR
-    );
+    throw new BlockManagerError('Block pack installation not yet implemented', BlockManagerErrorCode.STORAGE_ERROR);
   }
 
   /**
@@ -207,10 +200,7 @@ export class BlockManager {
   async uninstallBlockPack(packName: string): Promise<void> {
     // TODO: Implement block pack uninstallation
     // This will be implemented in a future phase
-    throw new BlockManagerError(
-      'Block pack uninstallation not yet implemented',
-      BlockManagerErrorCode.STORAGE_ERROR
-    );
+    throw new BlockManagerError('Block pack uninstallation not yet implemented', BlockManagerErrorCode.STORAGE_ERROR);
   }
 
   /**

--- a/packages/web_app/__tests__/QUICK_START.md
+++ b/packages/web_app/__tests__/QUICK_START.md
@@ -14,11 +14,13 @@ npm install
 ## Run Tests
 
 ### All Tests
+
 ```bash
 npm test
 ```
 
 ### Specific Test File
+
 ```bash
 npm test graphreducers.addblock
 npm test coordinates
@@ -26,12 +28,15 @@ npm test graphactions
 ```
 
 ### With Coverage Report
+
 ```bash
 npm test:coverage
 ```
+
 Then open `packages/web_app/__tests__/coverage/index.html` in your browser.
 
 ### Watch Mode (Auto-rerun on changes)
+
 ```bash
 npm test:watch
 ```
@@ -39,6 +44,7 @@ npm test:watch
 ## Expected Output
 
 All tests should pass:
+
 ```
 PASS  __tests__/store/actions/graphactions.test.ts
 PASS  __tests__/store/reducers/graphreducers.addblock.test.ts
@@ -53,18 +59,21 @@ Time:        3.456 s
 ## Troubleshooting
 
 ### "Cannot find module '@compx/common'"
+
 ```bash
 # From project root
 npm run bootstrap
 ```
 
 ### "Jest not found"
+
 ```bash
 cd packages/web_app
 npm install
 ```
 
 ### TypeScript errors
+
 ```bash
 # Rebuild common package
 cd packages/common
@@ -91,6 +100,7 @@ __tests__/
 ## Coverage Goals
 
 All metrics at 100%:
+
 - ✅ Statements
 - ✅ Branches
 - ✅ Functions

--- a/packages/web_app/__tests__/README.md
+++ b/packages/web_app/__tests__/README.md
@@ -38,29 +38,34 @@ Tests for the `AddBlockAction` action creator:
 Comprehensive tests for the ADD_BLOCK reducer case:
 
 #### Block Creation (5 tests)
+
 - Block structure validation
 - Unique ID generation (block + ports)
 - Multiple block handling
 - No ID conflicts
 
 #### Port Handling (1 test)
+
 - Multi-port template preservation
 - Port property correctness
 - Initial values preservation
 
 #### Error Handling (3 tests)
+
 - Missing blockTemplate handling
 - Null blockTemplate handling
 - Undefined blockTemplate handling
 - Console warning verification
 
 #### Position Handling (4 tests)
+
 - Positive coordinates
 - Negative coordinates
 - Zero coordinates
 - Large coordinate values
 
 #### State Immutability (2 tests)
+
 - Original state preservation
 - New state object creation
 - Deep cloning verification
@@ -72,35 +77,42 @@ Comprehensive tests for the ADD_BLOCK reducer case:
 Extensive tests for the `ScreenToWorld` helper function:
 
 #### Basic Transformations (3 tests)
+
 - Screen center to world origin
 - Corner coordinate mapping
 - Coordinate system verification
 
 #### Zoom Transformations (4 tests)
+
 - Zoom in (>1.0) scaling
 - Zoom out (<1.0) scaling
 - Very high zoom levels (10x)
 - Very low zoom levels (0.1x)
 
 #### Translation Transformations (3 tests)
+
 - Positive translation
 - Negative translation
 - Large translation values
 
 #### Combined Operations (2 tests)
+
 - Zoom + translation combinations
 - Complex transformation scenarios
 
 #### Y-Axis Inversion (2 tests)
+
 - Screen-to-world Y-axis flip
 - Y-inversion with zoom
 
 #### Edge Cases (3 tests)
+
 - Zero-sized screen handling
 - Very small zoom values
 - Non-square dimensions
 
 #### Real-World Scenarios (4 tests)
+
 - Drop at default position
 - Drop after panning
 - Drop after zooming
@@ -111,12 +123,14 @@ Extensive tests for the `ScreenToWorld` helper function:
 ## Running Tests
 
 ### Run All Tests
+
 ```bash
 cd packages/web_app
 npm test
 ```
 
 ### Run Specific Test Suite
+
 ```bash
 npm test graphreducers.addblock
 npm test coordinates
@@ -124,11 +138,13 @@ npm test graphactions
 ```
 
 ### Run with Coverage
+
 ```bash
 npm test -- --coverage
 ```
 
 ### Watch Mode
+
 ```bash
 npm test -- --watch
 ```
@@ -136,6 +152,7 @@ npm test -- --watch
 ## Test Dependencies
 
 The test suite uses:
+
 - **Jest**: Test framework
 - **@testing-library/jest-dom**: DOM matchers
 - **ts-jest**: TypeScript support
@@ -144,26 +161,34 @@ The test suite uses:
 ## Key Testing Patterns
 
 ### 1. State Immutability
+
 All reducer tests verify that:
+
 - Original state is never mutated
 - New state objects are created
 - Deep cloning works correctly
 
 ### 2. Unique ID Generation
+
 Tests verify UUID generation for:
+
 - Block IDs
 - Input port IDs
 - Output port IDs
 - No ID collisions
 
 ### 3. Coordinate Precision
+
 Coordinate tests use:
+
 - `toBeCloseTo(value, decimals)` for floating-point comparisons
 - 5 decimal places for standard precision
 - 2 decimal places for complex calculations
 
 ### 4. Error Handling
+
 All error cases include:
+
 - Console.warn spy verification
 - State preservation checks
 - Warning message validation
@@ -171,6 +196,7 @@ All error cases include:
 ## Coverage Goals
 
 Current coverage targets:
+
 - **Statements**: 100%
 - **Branches**: 100%
 - **Functions**: 100%
@@ -179,12 +205,15 @@ Current coverage targets:
 ## Future Test Additions
 
 Consider adding:
+
 1. **Component Tests**: React Testing Library tests for:
+
    - CardComponent drag behavior
    - LibraryViewer rendering
    - CanvasContainer drop handling
 
 2. **Integration Tests**: End-to-end tests for:
+
    - Complete drag-and-drop flow
    - Multi-block scenarios
    - Edge placement validation
@@ -206,17 +235,22 @@ When adding new features to the drag-and-drop functionality:
 ## Troubleshooting
 
 ### Module Resolution Issues
+
 If you see errors like "Cannot find module '@compx/common'":
+
 ```bash
 # From project root
 npm run bootstrap
 ```
 
 ### Canvas API Errors
+
 HTMLCanvasElement mocking is configured in `setupTests.ts`. If you encounter canvas-related errors, verify the mock is properly loaded.
 
 ### TypeScript Errors
+
 Ensure `tsconfig.json` includes test files:
+
 ```json
 {
   "include": ["src/**/*", "__tests__/**/*"]

--- a/packages/web_app/__tests__/jest.config.ts
+++ b/packages/web_app/__tests__/jest.config.ts
@@ -16,25 +16,26 @@ module.exports = {
     '^uuid$': require.resolve('uuid')
   },
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', {
-      tsconfig: {
-        skipLibCheck: true,
-        esModuleInterop: true,
-        allowSyntheticDefaultImports: true,
-        strict: false,
-        isolatedModules: true,
-        jsx: 'react',
-        moduleResolution: 'node',
-        resolveJsonModule: true,
-        target: 'es5',
-        module: 'commonjs',
-        lib: ['dom', 'dom.iterable', 'esnext']
-      },
-      isolatedModules: true
-    }],
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          skipLibCheck: true,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          strict: false,
+          isolatedModules: true,
+          jsx: 'react',
+          moduleResolution: 'node',
+          resolveJsonModule: true,
+          target: 'es5',
+          module: 'commonjs',
+          lib: ['dom', 'dom.iterable', 'esnext']
+        },
+        isolatedModules: true
+      }
+    ],
     '^.+\\.js$': 'babel-jest'
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(uuid)/)'
-  ]
+  transformIgnorePatterns: ['node_modules/(?!(uuid)/)']
 };

--- a/packages/web_app/__tests__/services/BlockService/ElectronBlockService.test.ts
+++ b/packages/web_app/__tests__/services/BlockService/ElectronBlockService.test.ts
@@ -45,10 +45,7 @@ describe('ElectronBlockService', () => {
 
   describe('constructor', () => {
     it('should setup IPC listeners on construction', () => {
-      expect(mockIpc.on).toHaveBeenCalledWith(
-        'block-library:changed',
-        expect.any(Function)
-      );
+      expect(mockIpc.on).toHaveBeenCalledWith('block-library:changed', expect.any(Function));
     });
   });
 
@@ -269,9 +266,7 @@ describe('ElectronBlockService', () => {
     it('should throw BlockServiceError on installation failure', async () => {
       mockIpc.invoke.mockRejectedValue(new Error('Installation failed'));
 
-      await expect(service.installBlockPack('invalid-url')).rejects.toThrow(
-        'Failed to install block pack'
-      );
+      await expect(service.installBlockPack('invalid-url')).rejects.toThrow('Failed to install block pack');
     });
   });
 
@@ -295,9 +290,7 @@ describe('ElectronBlockService', () => {
     it('should throw BlockServiceError on uninstallation failure', async () => {
       mockIpc.invoke.mockRejectedValue(new Error('Uninstallation failed'));
 
-      await expect(service.uninstallBlockPack('test-pack')).rejects.toThrow(
-        'Failed to uninstall block pack'
-      );
+      await expect(service.uninstallBlockPack('test-pack')).rejects.toThrow('Failed to uninstall block pack');
     });
   });
 
@@ -305,10 +298,7 @@ describe('ElectronBlockService', () => {
     it('should remove IPC listeners', () => {
       service.dispose();
 
-      expect(mockIpc.removeListener).toHaveBeenCalledWith(
-        'block-library:changed',
-        expect.any(Function)
-      );
+      expect(mockIpc.removeListener).toHaveBeenCalledWith('block-library:changed', expect.any(Function));
     });
 
     it('should clear all change listeners', () => {

--- a/packages/web_app/__tests__/services/BlockService/hooks/useBlock.test.tsx
+++ b/packages/web_app/__tests__/services/BlockService/hooks/useBlock.test.tsx
@@ -160,10 +160,9 @@ describe('useBlock', () => {
       mockService.getBlock.mockResolvedValue(mockBlock);
 
       // First render with cache disabled
-      const { result: result1, unmount: unmount1 } = renderHook(
-        () => useBlock('gain', { useCache: false }),
-        { wrapper }
-      );
+      const { result: result1, unmount: unmount1 } = renderHook(() => useBlock('gain', { useCache: false }), {
+        wrapper
+      });
 
       await waitFor(() => {
         expect(result1.current.loading).toBe(false);

--- a/packages/web_app/__tests__/services/BlockService/hooks/useBlockLibrary.test.tsx
+++ b/packages/web_app/__tests__/services/BlockService/hooks/useBlockLibrary.test.tsx
@@ -139,10 +139,9 @@ describe('useBlockLibrary', () => {
       mockService.getAvailableBlocks.mockResolvedValue(mockBlocks);
 
       // First render with cache disabled
-      const { result: result1, unmount: unmount1 } = renderHook(
-        () => useBlockLibrary({ useCache: false }),
-        { wrapper }
-      );
+      const { result: result1, unmount: unmount1 } = renderHook(() => useBlockLibrary({ useCache: false }), {
+        wrapper
+      });
 
       await waitFor(() => {
         expect(result1.current.loading).toBe(false);
@@ -198,9 +197,7 @@ describe('useBlockLibrary', () => {
       const mockBlocks1 = [createMockBlock('gain')];
       const mockBlocks2 = [createMockBlock('gain'), createMockBlock('sum')];
 
-      mockService.getAvailableBlocks
-        .mockResolvedValueOnce(mockBlocks1)
-        .mockResolvedValueOnce(mockBlocks2);
+      mockService.getAvailableBlocks.mockResolvedValueOnce(mockBlocks1).mockResolvedValueOnce(mockBlocks2);
 
       const { result } = renderHook(() => useBlockLibrary(), { wrapper });
 

--- a/packages/web_app/__tests__/store/actions/graphactions.test.ts
+++ b/packages/web_app/__tests__/store/actions/graphactions.test.ts
@@ -61,12 +61,7 @@ describe('Graph Actions - AddBlockAction', () => {
   });
 
   test('should handle different position values', () => {
-    const positions = [
-      new Vector2D(0, 0),
-      new Vector2D(100, -100),
-      new Vector2D(-500, 300),
-      new Vector2D(9999, -9999)
-    ];
+    const positions = [new Vector2D(0, 0), new Vector2D(100, -100), new Vector2D(-500, 300), new Vector2D(9999, -9999)];
 
     positions.forEach((position) => {
       const action = AddBlockAction(mockBlockTemplate, position);

--- a/packages/web_app/__tests__/store/reducers/graphreducers.addblock.test.ts
+++ b/packages/web_app/__tests__/store/reducers/graphreducers.addblock.test.ts
@@ -77,11 +77,7 @@ describe('GraphReducer - ADD_BLOCK Action', () => {
       expect(typeof addedBlock.outputPorts[0].id).toBe('string');
 
       // All IDs should be unique
-      const ids = [
-        addedBlock.id,
-        addedBlock.inputPorts[0].id,
-        addedBlock.outputPorts[0].id
-      ];
+      const ids = [addedBlock.id, addedBlock.inputPorts[0].id, addedBlock.outputPorts[0].id];
       const uniqueIds = new Set(ids);
       expect(uniqueIds.size).toBe(3);
     });

--- a/packages/web_app/src/app/Container/Canvas/CanvasContainer.tsx
+++ b/packages/web_app/src/app/Container/Canvas/CanvasContainer.tsx
@@ -114,7 +114,7 @@ class CanvasContainer extends Component<PropsType, StateType> {
       if (this.state.mouseDown?.mouseOn === 'PORT') {
         // Check if we didn't click on a port (in which case the port's handler already fired)
         // This will be called for mouseup on empty space
-        if (!e.target.hasName || !(e.target.hasName('port-hitbox'))) {
+        if (!e.target.hasName || !e.target.hasName('port-hitbox')) {
           this.mouseUpHandler();
         }
       }
@@ -489,7 +489,7 @@ function CanvasContainerDroppableWrapper(props: PropsType) {
           console.warn('⚠️ Drop failed - missing clientOffset or blockTemplate');
         }
       }
-  }),
+    }),
     [props.canvasZoom, props.canvasTranslation, props.onAddBlock]
   );
 

--- a/packages/web_app/src/app/Container/titlebar.css
+++ b/packages/web_app/src/app/Container/titlebar.css
@@ -1,4 +1,4 @@
 .titlebar {
-    -webkit-user-select: none;
-    -webkit-app-region: drag;
+  -webkit-user-select: none;
+  -webkit-app-region: drag;
 }

--- a/packages/web_app/src/app/electron-bar.css
+++ b/packages/web_app/src/app/electron-bar.css
@@ -1,4 +1,4 @@
 #electron-drag-bar {
-    -webkit-user-select: none;
-    -webkit-app-region: drag;
+  -webkit-user-select: none;
+  -webkit-app-region: drag;
 }

--- a/packages/web_app/src/services/BlockService/README.md
+++ b/packages/web_app/src/services/BlockService/README.md
@@ -36,7 +36,7 @@ function BlockPalette() {
 
   return (
     <ul>
-      {blocks.map(block => (
+      {blocks.map((block) => (
         <li key={block.name}>{block.name}</li>
       ))}
     </ul>
@@ -79,11 +79,13 @@ function BlockPalette() {
 ### 1. Platform Services
 
 **ElectronBlockService** (`services/electron/ElectronBlockService.ts`)
+
 - Uses Electron IPC for main process communication
 - File system-based block storage
 - Desktop-specific block pack installation
 
 **WebBlockService** (`services/web/WebBlockService.ts`)
+
 - REST API client for web server
 - HTTP-based block library access
 - Web-optimized caching strategy
@@ -91,6 +93,7 @@ function BlockPalette() {
 ### 2. Service Factory
 
 **getBlockService()** (`factory.ts`)
+
 - Automatic platform detection
 - Singleton pattern for service instances
 - Configuration support (API base URL)
@@ -98,6 +101,7 @@ function BlockPalette() {
 ### 3. React Context
 
 **BlockServiceProvider** (`context.tsx`)
+
 - Provides service instance to component tree
 - Synchronous initialization for test compatibility
 - Custom service injection for testing
@@ -105,12 +109,14 @@ function BlockPalette() {
 ### 4. React Hooks
 
 **useBlockLibrary()** (`hooks/useBlockLibrary.ts`)
+
 - Access all available blocks
 - Module-level caching with 60s TTL
 - Real-time library change events
 - Returns: `{ blocks, loading, error, refresh }`
 
 **useBlock(blockName)** (`hooks/useBlock.ts`)
+
 - Access specific block by name
 - Per-block Map cache with 60s TTL
 - Event-filtered updates (only for matching block)
@@ -123,22 +129,20 @@ function BlockPalette() {
 ```tsx
 interface BlockServiceProviderProps {
   children: ReactNode;
-  service?: BlockService;      // Optional custom service (for testing)
-  apiBaseUrl?: string;         // Optional API URL for WebBlockService
+  service?: BlockService; // Optional custom service (for testing)
+  apiBaseUrl?: string; // Optional API URL for WebBlockService
 }
 
-<BlockServiceProvider apiBaseUrl="https://api.example.com">
-  {children}
-</BlockServiceProvider>
+<BlockServiceProvider apiBaseUrl="https://api.example.com">{children}</BlockServiceProvider>;
 ```
 
 ### useBlockLibrary Hook
 
 ```tsx
 function useBlockLibrary(options?: {
-  autoRefresh?: boolean;  // default: true
-  useCache?: boolean;     // default: true
-}): BlockLibraryState
+  autoRefresh?: boolean; // default: true
+  useCache?: boolean; // default: true
+}): BlockLibraryState;
 
 interface BlockLibraryState {
   blocks: BlockDefinition[];
@@ -149,6 +153,7 @@ interface BlockLibraryState {
 ```
 
 **Example:**
+
 ```tsx
 const { blocks, loading, error, refresh } = useBlockLibrary();
 ```
@@ -159,10 +164,10 @@ const { blocks, loading, error, refresh } = useBlockLibrary();
 function useBlock(
   blockName: string,
   options?: {
-    autoRefresh?: boolean;  // default: true
-    useCache?: boolean;     // default: true
+    autoRefresh?: boolean; // default: true
+    useCache?: boolean; // default: true
   }
-): BlockState
+): BlockState;
 
 interface BlockState {
   block: BlockDefinition | null;
@@ -173,6 +178,7 @@ interface BlockState {
 ```
 
 **Example:**
+
 ```tsx
 const { block, loading, error, refresh } = useBlock('gain');
 ```
@@ -191,6 +197,7 @@ clearBlockLibraryCache(): void
 ```
 
 **Example:**
+
 ```tsx
 import { clearBlockCache, clearAllBlockCaches } from './services/BlockService';
 
@@ -229,12 +236,14 @@ When the library changes, components using the hooks automatically re-render wit
 ### Intelligent Caching
 
 **Cache Strategy:**
+
 - **TTL**: 60 seconds (1 minute)
 - **Cache Location**: Module-level (shared across component instances)
 - **Cache Invalidation**: Automatic on library change events
 - **Background Refresh**: Displays cached data immediately, refreshes if stale
 
 **Benefits:**
+
 - Reduces unnecessary service calls
 - Improves UI responsiveness
 - Supports offline-first scenarios
@@ -252,6 +261,7 @@ const { loading } = useBlockLibrary();
 ```
 
 **Smart Loading Logic:**
+
 - Shows `loading: true` only when cache is absent or stale
 - Shows cached data immediately even during background refresh
 - Provides optimal UX with instant feedback
@@ -269,6 +279,7 @@ if (error) {
 ```
 
 **Error Scenarios:**
+
 - Network failures
 - Service unavailable
 - Invalid block data
@@ -298,6 +309,7 @@ npm test -- packages/web_app/__tests__/services/BlockService/hooks
 ```
 
 **Test Coverage:**
+
 - Initial data loading
 - Caching behavior
 - Real-time update events
@@ -315,15 +327,11 @@ function TestWrapper({ children }) {
   const mockService = {
     getAvailableBlocks: jest.fn(),
     getBlock: jest.fn(),
-    onLibraryChanged: jest.fn(),
+    onLibraryChanged: jest.fn()
     // ... other methods
   };
 
-  return (
-    <BlockServiceProvider service={mockService}>
-      {children}
-    </BlockServiceProvider>
-  );
+  return <BlockServiceProvider service={mockService}>{children}</BlockServiceProvider>;
 }
 ```
 
@@ -348,6 +356,7 @@ function TestWrapper({ children }) {
 ### From Direct Service Usage
 
 **Before:**
+
 ```tsx
 function BlockList() {
   const [blocks, setBlocks] = useState([]);
@@ -357,22 +366,36 @@ function BlockList() {
     service.getAvailableBlocks().then(setBlocks);
   }, []);
 
-  return <ul>{blocks.map(b => <li>{b.name}</li>)}</ul>;
+  return (
+    <ul>
+      {blocks.map((b) => (
+        <li>{b.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
 **After:**
+
 ```tsx
 function BlockList() {
   const { blocks, loading } = useBlockLibrary();
 
   if (loading) return <div>Loading...</div>;
 
-  return <ul>{blocks.map(b => <li>{b.name}</li>)}</ul>;
+  return (
+    <ul>
+      {blocks.map((b) => (
+        <li>{b.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
 **Benefits:**
+
 - Automatic re-rendering on updates
 - Built-in loading/error states
 - Caching included
@@ -401,6 +424,7 @@ function BlockList() {
 **1. "useBlockServiceContext must be used within BlockServiceProvider"**
 
 Ensure provider wraps components using hooks:
+
 ```tsx
 <BlockServiceProvider>
   <YourComponents />
@@ -410,6 +434,7 @@ Ensure provider wraps components using hooks:
 **2. Stale cached data**
 
 Clear cache or use manual refresh:
+
 ```tsx
 const { refresh } = useBlockLibrary();
 await refresh();
@@ -418,11 +443,12 @@ await refresh();
 **3. Infinite re-renders**
 
 Don't include hook return values in useEffect dependencies:
+
 ```tsx
 const { blocks } = useBlockLibrary();
 useEffect(() => {
   // Process blocks
-}, [blocks.length]);  // Use length, not blocks array
+}, [blocks.length]); // Use length, not blocks array
 ```
 
 ## Future Enhancements

--- a/packages/web_app/src/services/BlockService/USAGE.md
+++ b/packages/web_app/src/services/BlockService/USAGE.md
@@ -42,7 +42,7 @@ function BlockPalette() {
       <h2>Available Blocks ({blocks.length})</h2>
       <button onClick={refresh}>Refresh</button>
       <ul>
-        {blocks.map(block => (
+        {blocks.map((block) => (
           <li key={block.name}>
             {block.name} - {block.description}
           </li>
@@ -99,6 +99,7 @@ const { blocks, refresh } = useBlockLibrary({
 ```
 
 **Options:**
+
 - `autoRefresh` (default: `true`): Automatically load data on mount
 - `useCache` (default: `true`): Use local caching for performance
 
@@ -167,7 +168,7 @@ function RobustBlockList() {
 
   return (
     <ul>
-      {blocks.map(block => (
+      {blocks.map((block) => (
         <li key={block.name}>{block.name}</li>
       ))}
     </ul>
@@ -195,12 +196,8 @@ function CacheSettings() {
 
   return (
     <div>
-      <button onClick={() => handleClearCache('gain')}>
-        Clear Gain Block Cache
-      </button>
-      <button onClick={handleClearAllCaches}>
-        Clear All Caches
-      </button>
+      <button onClick={() => handleClearCache('gain')}>Clear Gain Block Cache</button>
+      <button onClick={handleClearAllCaches}>Clear All Caches</button>
     </div>
   );
 }
@@ -217,11 +214,7 @@ import { createMockBlockService } from './testUtils';
 function TestWrapper({ children }) {
   const mockService = createMockBlockService();
 
-  return (
-    <BlockServiceProvider service={mockService}>
-      {children}
-    </BlockServiceProvider>
-  );
+  return <BlockServiceProvider service={mockService}>{children}</BlockServiceProvider>;
 }
 ```
 
@@ -241,6 +234,7 @@ const { blocks } = useBlockLibrary();
 ```
 
 **Cache Characteristics:**
+
 - **TTL**: 60 seconds (1 minute)
 - **Scope**:
   - `useBlockLibrary`: Module-level cache (shared across all instances)
@@ -275,7 +269,9 @@ function LazyBlockList() {
       {loading && <div>Loading...</div>}
       {blocks.length > 0 && (
         <ul>
-          {blocks.map(block => <li key={block.name}>{block.name}</li>)}
+          {blocks.map((block) => (
+            <li key={block.name}>{block.name}</li>
+          ))}
         </ul>
       )}
     </div>
@@ -309,8 +305,8 @@ interface BlockState {
 
 ```typescript
 interface HookOptions {
-  autoRefresh?: boolean;  // default: true
-  useCache?: boolean;     // default: true
+  autoRefresh?: boolean; // default: true
+  useCache?: boolean; // default: true
 }
 ```
 
@@ -323,24 +319,20 @@ function SearchableBlockList() {
   const { blocks, loading } = useBlockLibrary();
   const [search, setSearch] = React.useState('');
 
-  const filteredBlocks = blocks.filter(block =>
-    block.name.toLowerCase().includes(search.toLowerCase()) ||
-    block.description.toLowerCase().includes(search.toLowerCase())
+  const filteredBlocks = blocks.filter(
+    (block) =>
+      block.name.toLowerCase().includes(search.toLowerCase()) ||
+      block.description.toLowerCase().includes(search.toLowerCase())
   );
 
   return (
     <div>
-      <input
-        type="text"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search blocks..."
-      />
+      <input type="text" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search blocks..." />
       {loading ? (
         <div>Loading...</div>
       ) : (
         <ul>
-          {filteredBlocks.map(block => (
+          {filteredBlocks.map((block) => (
             <li key={block.name}>{block.name}</li>
           ))}
         </ul>
@@ -356,7 +348,7 @@ function SearchableBlockList() {
 function ConditionalBlockEditor() {
   const [selectedBlockName, setSelectedBlockName] = React.useState<string | null>(null);
   const { block, loading, error } = useBlock(selectedBlockName || '', {
-    autoRefresh: !!selectedBlockName  // only load if block is selected
+    autoRefresh: !!selectedBlockName // only load if block is selected
   });
 
   return (
@@ -387,11 +379,7 @@ function BlockCountBadge() {
 
   if (loading) return <span>...</span>;
 
-  return (
-    <span className="badge">
-      {blocks.length} blocks available
-    </span>
-  );
+  return <span className="badge">{blocks.length} blocks available</span>;
 }
 ```
 
@@ -424,7 +412,7 @@ Your components don't need to know about these differences - the hooks provide a
 ```tsx
 // ❌ Wrong
 function App() {
-  return <BlockList />;  // No provider
+  return <BlockList />; // No provider
 }
 
 // ✅ Correct
@@ -448,13 +436,13 @@ function App() {
 const { blocks } = useBlockLibrary();
 useEffect(() => {
   // Do something
-}, [blocks]);  // blocks reference changes on every render
+}, [blocks]); // blocks reference changes on every render
 
 // ✅ Correct
 const { blocks } = useBlockLibrary();
 useEffect(() => {
   // Do something
-}, [blocks.length]);  // Only depend on length
+}, [blocks.length]); // Only depend on length
 ```
 
 ### Stale Cache Data

--- a/packages/web_app/src/services/BlockService/context.tsx
+++ b/packages/web_app/src/services/BlockService/context.tsx
@@ -74,11 +74,7 @@ export function BlockServiceProvider({
     };
   }, [customService]);
 
-  return (
-    <BlockServiceContext.Provider value={{ service, ready }}>
-      {children}
-    </BlockServiceContext.Provider>
-  );
+  return <BlockServiceContext.Provider value={{ service, ready }}>{children}</BlockServiceContext.Provider>;
 }
 
 /**

--- a/packages/web_app/src/services/BlockService/factory.ts
+++ b/packages/web_app/src/services/BlockService/factory.ts
@@ -112,10 +112,7 @@ export function createBlockService(apiBaseUrl?: string): BlockService {
     }
 
     default: {
-      throw new BlockServiceError(
-        `Unsupported platform: ${platform}`,
-        BlockServiceErrorCode.UNKNOWN_ERROR
-      );
+      throw new BlockServiceError(`Unsupported platform: ${platform}`, BlockServiceErrorCode.UNKNOWN_ERROR);
     }
   }
 }

--- a/packages/web_app/src/services/BlockService/hooks/useBlockLibrary.ts
+++ b/packages/web_app/src/services/BlockService/hooks/useBlockLibrary.ts
@@ -59,10 +59,12 @@ const CACHE_TTL = 60000; // 1 minute cache TTL
  * }
  * ```
  */
-export function useBlockLibrary(options: {
-  autoRefresh?: boolean;
-  useCache?: boolean;
-} = {}): BlockLibraryState {
+export function useBlockLibrary(
+  options: {
+    autoRefresh?: boolean;
+    useCache?: boolean;
+  } = {}
+): BlockLibraryState {
   const { autoRefresh = true, useCache = true } = options;
   const service = useBlockServiceContext();
 

--- a/packages/web_app/src/services/BlockService/index.ts
+++ b/packages/web_app/src/services/BlockService/index.ts
@@ -23,11 +23,7 @@ export {
 } from './factory';
 
 // Export React context and provider
-export {
-  BlockServiceProvider,
-  useBlockServiceContext,
-  useBlockServiceReady
-} from './context';
+export { BlockServiceProvider, useBlockServiceContext, useBlockServiceReady } from './context';
 export type { BlockServiceProviderProps } from './context';
 
 // Export React hooks

--- a/packages/web_app/src/services/BlockService/interface.ts
+++ b/packages/web_app/src/services/BlockService/interface.ts
@@ -8,12 +8,7 @@
  */
 
 import { BlockDefinition } from '@compx/common';
-import {
-  BlockSearchQuery,
-  LibraryChangeEvent,
-  BlockPackInstallResult,
-  BlockPackUninstallResult
-} from './types';
+import { BlockSearchQuery, LibraryChangeEvent, BlockPackInstallResult, BlockPackUninstallResult } from './types';
 
 /**
  * Block library service interface

--- a/packages/web_app/src/services/BlockService/types.ts
+++ b/packages/web_app/src/services/BlockService/types.ts
@@ -88,11 +88,7 @@ export interface BlockPackUninstallResult {
  * Base error class for BlockService operations
  */
 export class BlockServiceError extends Error {
-  constructor(
-    message: string,
-    public readonly code: string,
-    public readonly details?: any
-  ) {
+  constructor(message: string, public readonly code: string, public readonly details?: any) {
     super(message);
     this.name = 'BlockServiceError';
     Object.setPrototypeOf(this, BlockServiceError.prototype);

--- a/packages/web_app/src/store/actions/graphactions.ts
+++ b/packages/web_app/src/store/actions/graphactions.ts
@@ -88,9 +88,7 @@ export const UpdateLibrary: ActionType = (): ActionPayloadType => ({
   payload: {}
 });
 
-export const LoadLibraryBlocksAction: ActionType = (
-  blocks: BlockStorageType<any, any>[]
-): ActionPayloadType => ({
+export const LoadLibraryBlocksAction: ActionType = (blocks: BlockStorageType<any, any>[]): ActionPayloadType => ({
   type: LoadLibraryBlocksActionType,
   payload: { blocks }
 });


### PR DESCRIPTION
- Enforce prettier on pre commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces Prettier across code/docs, adds lint-staged pre-commit formatting, updates lint/Jest configs, and applies minor TypeScript type and style cleanups.
> 
> - **Tooling/Formatting**:
>   - Add `lint-staged` to pre-commit via Husky; bump Prettier and configure repo-wide formatting.
>   - Tighten ESLint config (minor rule compaction) and streamline Jest configs (array formatting, coverage ignores).
> - **TypeScript/Code Cleanup**:
>   - Normalize tuple/indexed access types (e.g., `(typeof X)[number]`) across common modules; small style fixes in TS code and CSS.
>   - Minor defensive check tweak in `CanvasContainer.tsx` mouseup handler.
> - **Documentation**:
>   - Reformat and normalize Markdown across README and `claudedocs/` (lists, tables, code blocks, examples).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b28da3186435da52ad791f923fad05d2f221038f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->